### PR TITLE
Typo 02_state.md

### DIFF
--- a/x/pricefeed/spec/02_state.md
+++ b/x/pricefeed/spec/02_state.md
@@ -26,7 +26,7 @@ type Market struct {
 type Markets []Market
 ```
 
-`GenesisState` defines the state that must be persisted when the blockchain stops/stars in order for the normal function of the pricefeed to resume.
+`GenesisState` defines the state that must be persisted when the blockchain stops/starts in order for the normal function of the pricefeed to resume.
 
 ```go
 // GenesisState - pricefeed state that must be provided at genesis


### PR DESCRIPTION
### Description
Исправлена опечатка в документации в файле `02_state.md`, в строке описания `GenesisState`.
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/de469685-0fe3-4a9c-b928-a11af08e69c7">
