### PR TITLE
fix: read only

### DIFF
--- a/precompiles/common/errors.go
+++ b/precompiles/common/errors.go
@@ -4,4 +4,5 @@ const (
 	ErrGetStateDB          = "get EVM StateDB failed"
 	ErrInvalidNumberOfArgs = "invalid number of arguments; expected %d; got: %d"
 	ErrSenderNotOrigin     = "msg.sender is not from tx origin"
+	ErrWriteOnReadOnly     = "read only call to write functions"
 )

--- a/precompiles/dasigners/dasigners.go
+++ b/precompiles/dasigners/dasigners.go
@@ -92,6 +92,17 @@ func (d *DASignersPrecompile) RequiredGas(input []byte) uint64 {
 	return RequiredGasMax
 }
 
+func (d *DASignersPrecompile) IsTx(method string) bool {
+	switch method {
+	case DASignersFunctionUpdateSocket,
+		DASignersFunctionRegisterSigner,
+		DASignersFunctionRegisterNextEpoch:
+		return true
+	default:
+		return false
+	}
+}
+
 // Run implements vm.PrecompiledContract.
 func (d *DASignersPrecompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
 	// parse input
@@ -105,6 +116,10 @@ func (d *DASignersPrecompile) Run(evm *vm.EVM, contract *vm.Contract, readonly b
 	args, err := method.Inputs.Unpack(contract.Input[4:])
 	if err != nil {
 		return nil, err
+	}
+	// readonly check
+	if readonly && d.IsTx(method.Name) {
+		return nil, fmt.Errorf(precopmiles_common.ErrWriteOnReadOnly)
 	}
 	// get state db and context
 	stateDB, ok := evm.StateDB.(*statedb.StateDB)

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -67,6 +67,20 @@ func (s *StakingPrecompile) RequiredGas(input []byte) uint64 {
 	return 0
 }
 
+func (s *StakingPrecompile) IsTx(method string) bool {
+	switch method {
+	case StakingFunctionCreateValidator,
+		StakingFunctionEditValidator,
+		StakingFunctionDelegate,
+		StakingFunctionBeginRedelegate,
+		StakingFunctionUndelegate,
+		StakingFunctionCancelUnbondingDelegation:
+		return true
+	default:
+		return false
+	}
+}
+
 // Run implements vm.PrecompiledContract.
 func (s *StakingPrecompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
 	// parse input
@@ -80,6 +94,10 @@ func (s *StakingPrecompile) Run(evm *vm.EVM, contract *vm.Contract, readonly boo
 	args, err := method.Inputs.Unpack(contract.Input[4:])
 	if err != nil {
 		return nil, err
+	}
+	// readonly check
+	if readonly && s.IsTx(method.Name) {
+		return nil, fmt.Errorf(precopmiles_common.ErrWriteOnReadOnly)
 	}
 	// get state db and context
 	stateDB, ok := evm.StateDB.(*statedb.StateDB)


### PR DESCRIPTION
Throw error when a precompile receives a read only call to a non-view function. 

Current precompiles are not affected because they forbidden calls from contracts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-chain/92)
<!-- Reviewable:end -->
