### PR TITLE
refactor: precompile initialization, staking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -242,7 +242,7 @@ replace (
 	github.com/cometbft/cometbft-db => github.com/kava-labs/cometbft-db v0.9.1-kava.2
 	// Use cosmos-sdk fork with backported fix for unsafe-reset-all, staking transfer events, and custom tally handler support
 	// github.com/cosmos/cosmos-sdk => github.com/0glabs/cosmos-sdk v0.46.11-kava.3
-	github.com/cosmos/cosmos-sdk => github.com/0glabs/cosmos-sdk v0.47.10-0glabs.7
+	github.com/cosmos/cosmos-sdk => github.com/0glabs/cosmos-sdk v0.0.0-20241226164042-2543aa53eee1
 	github.com/cosmos/iavl => github.com/kava-labs/iavl v1.2.0-kava.1
 	// See https://github.com/cosmos/cosmos-sdk/pull/13093
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
@@ -250,7 +250,7 @@ replace (
 	// TODO: Tag before release
 	github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc2
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support
-	github.com/evmos/ethermint => github.com/0glabs/ethermint v0.21.0-0g.v3.1.7
+	github.com/evmos/ethermint => github.com/0glabs/ethermint v0.0.0-20241231151651-f7d1b1499e5a
 	// See https://github.com/cosmos/cosmos-sdk/pull/10401, https://github.com/cosmos/cosmos-sdk/commit/0592ba6158cd0bf49d894be1cef4faeec59e8320
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 	// Downgraded to avoid bugs in following commits which causes "version does not exist" errors

--- a/go.mod
+++ b/go.mod
@@ -242,7 +242,7 @@ replace (
 	github.com/cometbft/cometbft-db => github.com/kava-labs/cometbft-db v0.9.1-kava.2
 	// Use cosmos-sdk fork with backported fix for unsafe-reset-all, staking transfer events, and custom tally handler support
 	// github.com/cosmos/cosmos-sdk => github.com/0glabs/cosmos-sdk v0.46.11-kava.3
-	github.com/cosmos/cosmos-sdk => github.com/0glabs/cosmos-sdk v0.0.0-20241226164042-2543aa53eee1
+	github.com/cosmos/cosmos-sdk => github.com/0glabs/cosmos-sdk v0.47.10-0glabs.8
 	github.com/cosmos/iavl => github.com/kava-labs/iavl v1.2.0-kava.1
 	// See https://github.com/cosmos/cosmos-sdk/pull/13093
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
@@ -250,7 +250,7 @@ replace (
 	// TODO: Tag before release
 	github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc2
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support
-	github.com/evmos/ethermint => github.com/0glabs/ethermint v0.0.0-20241231151651-f7d1b1499e5a
+	github.com/evmos/ethermint => github.com/0glabs/ethermint v0.21.0-0g.v3.1.8
 	// See https://github.com/cosmos/cosmos-sdk/pull/10401, https://github.com/cosmos/cosmos-sdk/commit/0592ba6158cd0bf49d894be1cef4faeec59e8320
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 	// Downgraded to avoid bugs in following commits which causes "version does not exist" errors

--- a/go.sum
+++ b/go.sum
@@ -211,10 +211,10 @@ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFN
 git.sr.ht/~sircmpwn/go-bare v0.0.0-20210406120253-ab86bc2846d9/go.mod h1:BVJwbDfVjCjoFiKrhkei6NdGcZYpkDkdyCdg1ukytRA=
 github.com/0glabs/cometbft v0.37.9-0glabs.1 h1:KQJG17Y21suKP3QNICLto4b5Ak73XbSmKxeLbg0ZM68=
 github.com/0glabs/cometbft v0.37.9-0glabs.1/go.mod h1:j0Q3RqrCd+cztWCugs3obbzC4NyHGBPZZjtm/fWV00I=
-github.com/0glabs/cosmos-sdk v0.47.10-0glabs.7 h1:6+JquK9BaZZdIA3gx1AXhPBAdYCG+FQ94Y7FN35CvB4=
-github.com/0glabs/cosmos-sdk v0.47.10-0glabs.7/go.mod h1:KskIVnhXTFqrw7CDccMvx7To5KzUsOomIsQV7sPGOog=
-github.com/0glabs/ethermint v0.21.0-0g.v3.1.7 h1:wzr6z/LTsbjoAaBf0JkMtIDl/+B5KLd0GrU5brSZCY0=
-github.com/0glabs/ethermint v0.21.0-0g.v3.1.7/go.mod h1:S1Ahmqpzo1XUsfmmpGT7ok0hu5Fekz/pD6EDtXaBg9Q=
+github.com/0glabs/cosmos-sdk v0.0.0-20241226164042-2543aa53eee1 h1:5bREC0rOIpQDay71Weorv26WivJGRYnEk8kRH+jMPZg=
+github.com/0glabs/cosmos-sdk v0.0.0-20241226164042-2543aa53eee1/go.mod h1:KskIVnhXTFqrw7CDccMvx7To5KzUsOomIsQV7sPGOog=
+github.com/0glabs/ethermint v0.0.0-20241231151651-f7d1b1499e5a h1:C7edknSFFmB0PdXApWryR+3NjK8Lr/gHiYQ156rUahw=
+github.com/0glabs/ethermint v0.0.0-20241231151651-f7d1b1499e5a/go.mod h1:WD4qMi5eOSa34aMeNS7aYMdI5Yby+PK57sWmNqdKqJM=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=

--- a/go.sum
+++ b/go.sum
@@ -211,10 +211,10 @@ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFN
 git.sr.ht/~sircmpwn/go-bare v0.0.0-20210406120253-ab86bc2846d9/go.mod h1:BVJwbDfVjCjoFiKrhkei6NdGcZYpkDkdyCdg1ukytRA=
 github.com/0glabs/cometbft v0.37.9-0glabs.1 h1:KQJG17Y21suKP3QNICLto4b5Ak73XbSmKxeLbg0ZM68=
 github.com/0glabs/cometbft v0.37.9-0glabs.1/go.mod h1:j0Q3RqrCd+cztWCugs3obbzC4NyHGBPZZjtm/fWV00I=
-github.com/0glabs/cosmos-sdk v0.0.0-20241226164042-2543aa53eee1 h1:5bREC0rOIpQDay71Weorv26WivJGRYnEk8kRH+jMPZg=
-github.com/0glabs/cosmos-sdk v0.0.0-20241226164042-2543aa53eee1/go.mod h1:KskIVnhXTFqrw7CDccMvx7To5KzUsOomIsQV7sPGOog=
-github.com/0glabs/ethermint v0.0.0-20241231151651-f7d1b1499e5a h1:C7edknSFFmB0PdXApWryR+3NjK8Lr/gHiYQ156rUahw=
-github.com/0glabs/ethermint v0.0.0-20241231151651-f7d1b1499e5a/go.mod h1:WD4qMi5eOSa34aMeNS7aYMdI5Yby+PK57sWmNqdKqJM=
+github.com/0glabs/cosmos-sdk v0.47.10-0glabs.8 h1:IaNin0677A6terTnw3WOGmYOY2w4h0LugBhK6VugXMg=
+github.com/0glabs/cosmos-sdk v0.47.10-0glabs.8/go.mod h1:KskIVnhXTFqrw7CDccMvx7To5KzUsOomIsQV7sPGOog=
+github.com/0glabs/ethermint v0.21.0-0g.v3.1.8 h1:/jxCtO5B8amXgGZ0MWcoIH32PmoU9Z+WfPxA8nLaZI8=
+github.com/0glabs/ethermint v0.21.0-0g.v3.1.8/go.mod h1:1GrxH8zkhO/x8sinIxaFtolK50spzSAZISbdP1MDLy8=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=

--- a/precompiles/common/common.go
+++ b/precompiles/common/common.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"errors"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/evmos/ethermint/x/evm/statedb"
+)
+
+type PrecompileCommon interface {
+	Abi() *abi.ABI
+	IsTx(string) bool
+	KVGasConfig() storetypes.GasConfig
+}
+
+func InitializePrecompileCall(
+	p PrecompileCommon,
+	evm *vm.EVM,
+	contract *vm.Contract,
+	readonly bool,
+) (
+	ctx sdk.Context,
+	stateDB *statedb.StateDB,
+	method *abi.Method,
+	initialGas storetypes.Gas,
+	args []interface{},
+	err error,
+) {
+	// parse input
+	if len(contract.Input) < 4 {
+		return sdk.Context{}, nil, nil, uint64(0), nil, vm.ErrExecutionReverted
+	}
+	method, err = p.Abi().MethodById(contract.Input[:4])
+	if err != nil {
+		return sdk.Context{}, nil, nil, uint64(0), nil, vm.ErrExecutionReverted
+	}
+	args, err = method.Inputs.Unpack(contract.Input[4:])
+	if err != nil {
+		return sdk.Context{}, nil, nil, uint64(0), nil, err
+	}
+	// readonly check
+	if readonly && p.IsTx(method.Name) {
+		return sdk.Context{}, nil, nil, uint64(0), nil, errors.New(ErrWriteOnReadOnly)
+	}
+	// get state db and context
+	stateDB, ok := evm.StateDB.(*statedb.StateDB)
+	if !ok {
+		return sdk.Context{}, nil, nil, uint64(0), nil, errors.New(ErrGetStateDB)
+	}
+	ctx, err = stateDB.GetCachedContextForPrecompile()
+	if err != nil {
+		return sdk.Context{}, nil, nil, uint64(0), nil, err
+	}
+	// initial gas
+	initialGas = ctx.GasMeter().GasConsumed()
+	ctx = ctx.WithKVGasConfig(p.KVGasConfig())
+
+	return ctx, stateDB, method, initialGas, args, nil
+}

--- a/precompiles/dasigners/dasigners.go
+++ b/precompiles/dasigners/dasigners.go
@@ -1,16 +1,14 @@
 package dasigners
 
 import (
-	"fmt"
 	"strings"
 
-	precopmiles_common "github.com/0glabs/0g-chain/precompiles/common"
+	precompiles_common "github.com/0glabs/0g-chain/precompiles/common"
 	dasignerskeeper "github.com/0glabs/0g-chain/x/dasigners/v1/keeper"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/evmos/ethermint/x/evm/statedb"
 )
 
 const (
@@ -47,17 +45,8 @@ var RequiredGasBasic = map[string]uint64{
 	DASignersFunctionRegisteredEpoch:   10000,
 }
 
-var KVGasConfig storetypes.GasConfig = storetypes.GasConfig{
-	HasCost:          0,
-	DeleteCost:       0,
-	ReadCostFlat:     0,
-	ReadCostPerByte:  0,
-	WriteCostFlat:    0,
-	WriteCostPerByte: 0,
-	IterNextCostFlat: 0,
-}
-
 var _ vm.PrecompiledContract = &DASignersPrecompile{}
+var _ precompiles_common.PrecompileCommon = &DASignersPrecompile{}
 
 type DASignersPrecompile struct {
 	abi             abi.ABI
@@ -103,33 +92,20 @@ func (d *DASignersPrecompile) IsTx(method string) bool {
 	}
 }
 
+func (d *DASignersPrecompile) Abi() *abi.ABI {
+	return &d.abi
+}
+
+func (d *DASignersPrecompile) KVGasConfig() storetypes.GasConfig {
+	return storetypes.KVGasConfig()
+}
+
 // Run implements vm.PrecompiledContract.
 func (d *DASignersPrecompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
-	// parse input
-	if len(contract.Input) < 4 {
-		return nil, vm.ErrExecutionReverted
-	}
-	method, err := d.abi.MethodById(contract.Input[:4])
-	if err != nil {
-		return nil, vm.ErrExecutionReverted
-	}
-	args, err := method.Inputs.Unpack(contract.Input[4:])
+	ctx, stateDB, method, initialGas, args, err := precompiles_common.InitializePrecompileCall(d, evm, contract, readonly)
 	if err != nil {
 		return nil, err
 	}
-	// readonly check
-	if readonly && d.IsTx(method.Name) {
-		return nil, fmt.Errorf(precopmiles_common.ErrWriteOnReadOnly)
-	}
-	// get state db and context
-	stateDB, ok := evm.StateDB.(*statedb.StateDB)
-	if !ok {
-		return nil, fmt.Errorf(precopmiles_common.ErrGetStateDB)
-	}
-	ctx := stateDB.GetContext()
-	// reset gas config
-	ctx = ctx.WithKVGasConfig(KVGasConfig)
-	initialGas := ctx.GasMeter().GasConsumed()
 
 	var bz []byte
 	switch method.Name {

--- a/precompiles/dasigners/dasigners_test.go
+++ b/precompiles/dasigners/dasigners_test.go
@@ -1,6 +1,7 @@
 package dasigners_test
 
 import (
+	"fmt"
 	"math/big"
 	"strings"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	"cosmossdk.io/math"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/evmos/ethermint/x/evm/statedb"
 )
 
 type DASignersTestSuite struct {
@@ -99,7 +101,11 @@ func (suite *DASignersTestSuite) runTx(input []byte, signer *testutil.TestSigner
 	precompiles := suite.EvmKeeper.GetPrecompiles()
 	evm.WithPrecompiles(precompiles, []common.Address{suite.addr})
 
-	return suite.dasigners.Run(evm, contract, false)
+	bz, err := suite.dasigners.Run(evm, contract, false)
+	if err == nil {
+		evm.StateDB.(*statedb.StateDB).Commit()
+	}
+	return bz, err
 }
 
 func (suite *DASignersTestSuite) registerSigner(testSigner *testutil.TestSigner, sk *big.Int) *types.Signer {
@@ -308,8 +314,11 @@ func (suite *DASignersTestSuite) Test_DASigners() {
 	suite.AddDelegation(suite.signerOne.HexAddr, suite.signerOne.HexAddr, keeper.BondedConversionRate.Mul(sdk.NewIntFromUint64(params.TokensPerVote)))
 	suite.AddDelegation(suite.signerTwo.HexAddr, suite.signerOne.HexAddr, keeper.BondedConversionRate.Mul(sdk.NewIntFromUint64(params.TokensPerVote)).Mul(sdk.NewIntFromUint64(2)))
 	// tx test
+	fmt.Println("registering signer 1..")
 	signer1 := suite.registerSigner(suite.signerOne, big.NewInt(1))
+	fmt.Println("registering signer 2..")
 	signer2 := suite.registerSigner(suite.signerTwo, big.NewInt(11))
+	fmt.Println("signers registered..")
 	suite.updateSocket(suite.signerOne, signer1)
 	suite.updateSocket(suite.signerTwo, signer2)
 	suite.registerEpoch(suite.signerOne, big.NewInt(1))

--- a/precompiles/dasigners/query.go
+++ b/precompiles/dasigners/query.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
-	precopmiles_common "github.com/0glabs/0g-chain/precompiles/common"
+	precompiles_common "github.com/0glabs/0g-chain/precompiles/common"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -60,9 +60,9 @@ func (d *DASignersPrecompile) GetSigner(ctx sdk.Context, _ *vm.EVM, method *abi.
 
 func (d *DASignersPrecompile) IsSigner(ctx sdk.Context, _ *vm.EVM, method *abi.Method, args []interface{}) ([]byte, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 1, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 1, len(args))
 	}
-	account := precopmiles_common.ToLowerHexWithoutPrefix(args[0].(common.Address))
+	account := precompiles_common.ToLowerHexWithoutPrefix(args[0].(common.Address))
 	_, found, err := d.dasignersKeeper.GetSigner(ctx, account)
 	if err != nil {
 		return nil, err
@@ -72,9 +72,9 @@ func (d *DASignersPrecompile) IsSigner(ctx sdk.Context, _ *vm.EVM, method *abi.M
 
 func (d *DASignersPrecompile) RegisteredEpoch(ctx sdk.Context, _ *vm.EVM, method *abi.Method, args []interface{}) ([]byte, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	account := precopmiles_common.ToLowerHexWithoutPrefix(args[0].(common.Address))
+	account := precompiles_common.ToLowerHexWithoutPrefix(args[0].(common.Address))
 	epoch := args[1].(*big.Int).Uint64()
 	_, found, err := d.dasignersKeeper.GetRegistration(ctx, epoch, account)
 	if err != nil {

--- a/precompiles/dasigners/tx.go
+++ b/precompiles/dasigners/tx.go
@@ -1,6 +1,7 @@
 package dasigners
 
 import (
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -8,7 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/evmos/ethermint/x/evm/statedb"
 
-	precopmiles_common "github.com/0glabs/0g-chain/precompiles/common"
+	precompiles_common "github.com/0glabs/0g-chain/precompiles/common"
 )
 
 func (d *DASignersPrecompile) RegisterSigner(
@@ -24,12 +25,12 @@ func (d *DASignersPrecompile) RegisterSigner(
 		return nil, err
 	}
 	// validation
-	sender := precopmiles_common.ToLowerHexWithoutPrefix(evm.Origin)
+	sender := precompiles_common.ToLowerHexWithoutPrefix(evm.Origin)
 	if sender != msg.Signer.Account {
 		return nil, fmt.Errorf(ErrInvalidSender, sender, msg.Signer.Account)
 	}
 	if contract.CallerAddress != evm.Origin {
-		return nil, fmt.Errorf(precopmiles_common.ErrSenderNotOrigin)
+		return nil, errors.New(precompiles_common.ErrSenderNotOrigin)
 	}
 	// execute
 	_, err = d.dasignersKeeper.RegisterSigner(sdk.WrapSDKContext(ctx), msg)
@@ -52,13 +53,13 @@ func (d *DASignersPrecompile) RegisterNextEpoch(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, err := NewMsgRegisterNextEpoch(args, precopmiles_common.ToLowerHexWithoutPrefix(evm.Origin))
+	msg, err := NewMsgRegisterNextEpoch(args, precompiles_common.ToLowerHexWithoutPrefix(evm.Origin))
 	if err != nil {
 		return nil, err
 	}
 	// validation
 	if contract.CallerAddress != evm.Origin {
-		return nil, fmt.Errorf(precopmiles_common.ErrSenderNotOrigin)
+		return nil, errors.New(precompiles_common.ErrSenderNotOrigin)
 	}
 	// execute
 	_, err = d.dasignersKeeper.RegisterNextEpoch(sdk.WrapSDKContext(ctx), msg)
@@ -76,13 +77,13 @@ func (d *DASignersPrecompile) UpdateSocket(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, err := NewMsgUpdateSocket(args, precopmiles_common.ToLowerHexWithoutPrefix(evm.Origin))
+	msg, err := NewMsgUpdateSocket(args, precompiles_common.ToLowerHexWithoutPrefix(evm.Origin))
 	if err != nil {
 		return nil, err
 	}
 	// validation
 	if contract.CallerAddress != evm.Origin {
-		return nil, fmt.Errorf(precopmiles_common.ErrSenderNotOrigin)
+		return nil, errors.New(precompiles_common.ErrSenderNotOrigin)
 	}
 	// execute
 	_, err = d.dasignersKeeper.UpdateSocket(sdk.WrapSDKContext(ctx), msg)

--- a/precompiles/dasigners/types.go
+++ b/precompiles/dasigners/types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
-	precopmiles_common "github.com/0glabs/0g-chain/precompiles/common"
+	precompiles_common "github.com/0glabs/0g-chain/precompiles/common"
 	dasignerstypes "github.com/0glabs/0g-chain/x/dasigners/v1/types"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -72,7 +72,7 @@ func SerializeG2(p BN254G2Point) []byte {
 
 func NewQueryQuorumCountRequest(args []interface{}) (*dasignerstypes.QueryQuorumCountRequest, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 1, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 1, len(args))
 	}
 
 	return &dasignerstypes.QueryQuorumCountRequest{
@@ -82,21 +82,21 @@ func NewQueryQuorumCountRequest(args []interface{}) (*dasignerstypes.QueryQuorum
 
 func NewQuerySignerRequest(args []interface{}) (*dasignerstypes.QuerySignerRequest, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 1, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 1, len(args))
 	}
 	accounts := args[0].([]common.Address)
 	req := dasignerstypes.QuerySignerRequest{
 		Accounts: make([]string, len(accounts)),
 	}
 	for i, account := range accounts {
-		req.Accounts[i] = precopmiles_common.ToLowerHexWithoutPrefix(account)
+		req.Accounts[i] = precompiles_common.ToLowerHexWithoutPrefix(account)
 	}
 	return &req, nil
 }
 
 func NewQueryEpochQuorumRequest(args []interface{}) (*dasignerstypes.QueryEpochQuorumRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
 
 	return &dasignerstypes.QueryEpochQuorumRequest{
@@ -107,7 +107,7 @@ func NewQueryEpochQuorumRequest(args []interface{}) (*dasignerstypes.QueryEpochQ
 
 func NewQueryEpochQuorumRowRequest(args []interface{}) (*dasignerstypes.QueryEpochQuorumRowRequest, error) {
 	if len(args) != 3 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 3, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 3, len(args))
 	}
 
 	return &dasignerstypes.QueryEpochQuorumRowRequest{
@@ -119,7 +119,7 @@ func NewQueryEpochQuorumRowRequest(args []interface{}) (*dasignerstypes.QueryEpo
 
 func NewQueryAggregatePubkeyG1Request(args []interface{}) (*dasignerstypes.QueryAggregatePubkeyG1Request, error) {
 	if len(args) != 3 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 3, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 3, len(args))
 	}
 
 	return &dasignerstypes.QueryAggregatePubkeyG1Request{
@@ -140,13 +140,13 @@ func NewIDASignersSignerDetail(signer *dasignerstypes.Signer) IDASignersSignerDe
 
 func NewMsgRegisterSigner(args []interface{}) (*dasignerstypes.MsgRegisterSigner, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
 
 	signer := args[0].(IDASignersSignerDetail)
 	return &dasignerstypes.MsgRegisterSigner{
 		Signer: &dasignerstypes.Signer{
-			Account:  precopmiles_common.ToLowerHexWithoutPrefix(signer.Signer),
+			Account:  precompiles_common.ToLowerHexWithoutPrefix(signer.Signer),
 			Socket:   signer.Socket,
 			PubkeyG1: SerializeG1(signer.PkG1),
 			PubkeyG2: SerializeG2(signer.PkG2),
@@ -157,7 +157,7 @@ func NewMsgRegisterSigner(args []interface{}) (*dasignerstypes.MsgRegisterSigner
 
 func NewMsgRegisterNextEpoch(args []interface{}, account string) (*dasignerstypes.MsgRegisterNextEpoch, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 1, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 1, len(args))
 	}
 
 	return &dasignerstypes.MsgRegisterNextEpoch{
@@ -168,7 +168,7 @@ func NewMsgRegisterNextEpoch(args []interface{}, account string) (*dasignerstype
 
 func NewMsgUpdateSocket(args []interface{}, account string) (*dasignerstypes.MsgUpdateSocket, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 1, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 1, len(args))
 	}
 
 	return &dasignerstypes.MsgUpdateSocket{

--- a/precompiles/interfaces/contracts/IStaking.sol
+++ b/precompiles/interfaces/contracts/IStaking.sol
@@ -34,7 +34,7 @@ struct Commission {
  * @dev Validator defines a validator.
  */
 struct Validator {
-    string operatorAddress;
+    address operatorAddress;
     string consensusPubkey;
     bool jailed;
     BondStatus status;
@@ -53,8 +53,8 @@ struct Validator {
  * @dev Delegation represents the bond with tokens held by an account.
  */
 struct Delegation {
-    string delegatorAddress;
-    string validatorAddress;
+    address delegatorAddress;
+    address validatorAddress;
     uint shares; // 18 decimals
 }
 
@@ -85,8 +85,8 @@ struct UnbondingDelegationEntry {
  * for a single validator in an time-ordered list.
  */
 struct UnbondingDelegation {
-    string delegatorAddress;
-    string validatorAddress;
+    address delegatorAddress;
+    address validatorAddress;
     UnbondingDelegationEntry[] entries;
 }
 
@@ -105,9 +105,9 @@ struct RedelegationResponse {
  * from a particular source validator to a particular destination validator.
  */
 struct Redelegation {
-    string delegatorAddress;
-    string validatorSrcAddress;
-    string validatorDstAddress;
+    address delegatorAddress;
+    address validatorSrcAddress;
+    address validatorDstAddress;
     RedelegationEntry[] entries;
 }
 
@@ -204,7 +204,7 @@ interface IStaking {
      * cosmos grpc: rpc Delegate(MsgDelegate) returns (MsgDelegateResponse);
      */
     function delegate(
-        string memory validatorAddress,
+        address validatorAddress,
         uint amount // in bond denom
     ) external;
 
@@ -215,8 +215,8 @@ interface IStaking {
      * cosmos grpc: rpc BeginRedelegate(MsgBeginRedelegate) returns (MsgBeginRedelegateResponse);
      */
     function beginRedelegate(
-        string memory validatorSrcAddress,
-        string memory validatorDstAddress,
+        address validatorSrcAddress,
+        address validatorDstAddress,
         uint amount // in bond denom
     ) external returns (uint completionTime);
 
@@ -227,7 +227,7 @@ interface IStaking {
      * cosmos grpc: rpc Undelegate(MsgUndelegate) returns (MsgUndelegateResponse);
      */
     function undelegate(
-        string memory validatorAddress,
+        address validatorAddress,
         uint amount // in bond denom
     ) external returns (uint completionTime);
 
@@ -239,7 +239,7 @@ interface IStaking {
      * cosmos grpc: rpc CancelUnbondingDelegation(MsgCancelUnbondingDelegation) returns (MsgCancelUnbondingDelegationResponse);
      */
     function cancelUnbondingDelegation(
-        string memory validatorAddress,
+        address validatorAddress,
         uint amount, // in bond denom
         uint creationHeight
     ) external;
@@ -273,7 +273,7 @@ interface IStaking {
      * cosmos grpc: rpc Validator(QueryValidatorRequest) returns (QueryValidatorResponse);
      */
     function validator(
-        string memory validatorAddress
+        address validatorAddress
     ) external view returns (Validator memory validator);
 
     /**
@@ -281,7 +281,7 @@ interface IStaking {
      * cosmos grpc: rpc ValidatorDelegations(QueryValidatorDelegationsRequest) returns (QueryValidatorDelegationsResponse);
      */
     function validatorDelegations(
-        string memory validatorAddr,
+        address validatorAddr,
         PageRequest memory pagination
     )
         external
@@ -297,7 +297,7 @@ interface IStaking {
      */
     //
     function validatorUnbondingDelegations(
-        string memory validatorAddr,
+        address validatorAddr,
         PageRequest memory pagination
     )
         external
@@ -312,8 +312,8 @@ interface IStaking {
      * cosmos grpc: rpc Delegation(QueryDelegationRequest) returns (QueryDelegationResponse);
      */
     function delegation(
-        string memory delegatorAddr,
-        string memory validatorAddr
+        address delegatorAddr,
+        address validatorAddr
     ) external view returns (Delegation memory delegation, uint balance);
 
     /**
@@ -321,8 +321,8 @@ interface IStaking {
      * cosmos grpc: rpc UnbondingDelegation(QueryUnbondingDelegationRequest) returns (QueryUnbondingDelegationResponse);
      */
     function unbondingDelegation(
-        string memory delegatorAddr,
-        string memory validatorAddr
+        address delegatorAddr,
+        address validatorAddr
     ) external view returns (UnbondingDelegation memory unbond);
 
     /**
@@ -331,7 +331,7 @@ interface IStaking {
      * cosmos grpc: rpc DelegatorDelegations(QueryDelegatorDelegationsRequest) returns (QueryDelegatorDelegationsResponse);
      */
     function delegatorDelegations(
-        string memory delegatorAddr,
+        address delegatorAddr,
         PageRequest memory pagination
     )
         external
@@ -346,7 +346,7 @@ interface IStaking {
      * cosmos grpc: rpc DelegatorUnbondingDelegations(QueryDelegatorUnbondingDelegationsRequest)
      */
     function delegatorUnbondingDelegations(
-        string memory delegatorAddr,
+        address delegatorAddr,
         PageRequest memory pagination
     )
         external
@@ -362,9 +362,9 @@ interface IStaking {
      * grpc: rpc Redelegations(QueryRedelegationsRequest) returns (QueryRedelegationsResponse);
      */
     function redelegations(
-        string memory delegatorAddress,
-        string memory srcValidatorAddress,
-        string memory dstValidatorAddress,
+        address delegatorAddress,
+        address srcValidatorAddress,
+        address dstValidatorAddress,
         PageRequest calldata pageRequest
     )
         external
@@ -379,7 +379,7 @@ interface IStaking {
      * cosmos grpc: rpc DelegatorValidators(QueryDelegatorValidatorsRequest) returns (QueryDelegatorValidatorsResponse);
      */
     function delegatorValidators(
-        string memory delegatorAddr,
+        address delegatorAddr,
         PageRequest memory pagination
     )
         external
@@ -394,8 +394,8 @@ interface IStaking {
      * cosmos grpc: rpc DelegatorValidator(QueryDelegatorValidatorRequest) returns (QueryDelegatorValidatorResponse);
      */
     function delegatorValidator(
-        string memory delegatorAddr,
-        string memory validatorAddr
+        address delegatorAddr,
+        address validatorAddr
     ) external view returns (Validator memory validator);
 
     /**

--- a/precompiles/staking/IStaking.abi
+++ b/precompiles/staking/IStaking.abi
@@ -2,14 +2,14 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorSrcAddress",
-        "type": "string"
+        "type": "address"
       },
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorDstAddress",
-        "type": "string"
+        "type": "address"
       },
       {
         "internalType": "uint256",
@@ -31,9 +31,9 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorAddress",
-        "type": "string"
+        "type": "address"
       },
       {
         "internalType": "uint256",
@@ -131,9 +131,9 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorAddress",
-        "type": "string"
+        "type": "address"
       },
       {
         "internalType": "uint256",
@@ -149,14 +149,14 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "delegatorAddr",
-        "type": "string"
+        "type": "address"
       },
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorAddr",
-        "type": "string"
+        "type": "address"
       }
     ],
     "name": "delegation",
@@ -164,14 +164,14 @@
       {
         "components": [
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "delegatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "validatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
             "internalType": "uint256",
@@ -195,9 +195,9 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "delegatorAddr",
-        "type": "string"
+        "type": "address"
       },
       {
         "components": [
@@ -239,14 +239,14 @@
           {
             "components": [
               {
-                "internalType": "string",
+                "internalType": "address",
                 "name": "delegatorAddress",
-                "type": "string"
+                "type": "address"
               },
               {
-                "internalType": "string",
+                "internalType": "address",
                 "name": "validatorAddress",
-                "type": "string"
+                "type": "address"
               },
               {
                 "internalType": "uint256",
@@ -292,9 +292,9 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "delegatorAddr",
-        "type": "string"
+        "type": "address"
       },
       {
         "components": [
@@ -334,14 +334,14 @@
       {
         "components": [
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "delegatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "validatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
             "components": [
@@ -409,14 +409,14 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "delegatorAddr",
-        "type": "string"
+        "type": "address"
       },
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorAddr",
-        "type": "string"
+        "type": "address"
       }
     ],
     "name": "delegatorValidator",
@@ -424,9 +424,9 @@
       {
         "components": [
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "operatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
             "internalType": "string",
@@ -556,9 +556,9 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "delegatorAddr",
-        "type": "string"
+        "type": "address"
       },
       {
         "components": [
@@ -598,9 +598,9 @@
       {
         "components": [
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "operatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
             "internalType": "string",
@@ -884,19 +884,19 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "delegatorAddress",
-        "type": "string"
+        "type": "address"
       },
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "srcValidatorAddress",
-        "type": "string"
+        "type": "address"
       },
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "dstValidatorAddress",
-        "type": "string"
+        "type": "address"
       },
       {
         "components": [
@@ -938,19 +938,19 @@
           {
             "components": [
               {
-                "internalType": "string",
+                "internalType": "address",
                 "name": "delegatorAddress",
-                "type": "string"
+                "type": "address"
               },
               {
-                "internalType": "string",
+                "internalType": "address",
                 "name": "validatorSrcAddress",
-                "type": "string"
+                "type": "address"
               },
               {
-                "internalType": "string",
+                "internalType": "address",
                 "name": "validatorDstAddress",
-                "type": "string"
+                "type": "address"
               },
               {
                 "components": [
@@ -1072,14 +1072,14 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "delegatorAddr",
-        "type": "string"
+        "type": "address"
       },
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorAddr",
-        "type": "string"
+        "type": "address"
       }
     ],
     "name": "unbondingDelegation",
@@ -1087,14 +1087,14 @@
       {
         "components": [
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "delegatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "validatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
             "components": [
@@ -1145,9 +1145,9 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorAddress",
-        "type": "string"
+        "type": "address"
       },
       {
         "internalType": "uint256",
@@ -1169,9 +1169,9 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorAddress",
-        "type": "string"
+        "type": "address"
       }
     ],
     "name": "validator",
@@ -1179,9 +1179,9 @@
       {
         "components": [
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "operatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
             "internalType": "string",
@@ -1311,9 +1311,9 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorAddr",
-        "type": "string"
+        "type": "address"
       },
       {
         "components": [
@@ -1355,14 +1355,14 @@
           {
             "components": [
               {
-                "internalType": "string",
+                "internalType": "address",
                 "name": "delegatorAddress",
-                "type": "string"
+                "type": "address"
               },
               {
-                "internalType": "string",
+                "internalType": "address",
                 "name": "validatorAddress",
-                "type": "string"
+                "type": "address"
               },
               {
                 "internalType": "uint256",
@@ -1408,9 +1408,9 @@
   {
     "inputs": [
       {
-        "internalType": "string",
+        "internalType": "address",
         "name": "validatorAddr",
-        "type": "string"
+        "type": "address"
       },
       {
         "components": [
@@ -1450,14 +1450,14 @@
       {
         "components": [
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "delegatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "validatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
             "components": [
@@ -1567,9 +1567,9 @@
       {
         "components": [
           {
-            "internalType": "string",
+            "internalType": "address",
             "name": "operatorAddress",
-            "type": "string"
+            "type": "address"
           },
           {
             "internalType": "string",

--- a/precompiles/staking/contract.go
+++ b/precompiles/staking/contract.go
@@ -30,7 +30,7 @@ var (
 
 // StakingMetaData contains all meta data concerning the Staking contract.
 var StakingMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"validatorSrcAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorDstAddress\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"beginRedelegate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"}],\"name\":\"cancelUnbondingDelegation\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"pubkey\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"createValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"delegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"delegatorAddr\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorAddr\",\"type\":\"string\"}],\"name\":\"delegation\",\"outputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"delegatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"internalType\":\"structDelegation\",\"name\":\"delegation\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"delegatorAddr\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"delegatorDelegations\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"delegatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"internalType\":\"structDelegation\",\"name\":\"delegation\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"internalType\":\"structDelegationResponse[]\",\"name\":\"delegationResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"delegatorAddr\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"delegatorUnbondingDelegations\",\"outputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"delegatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structUnbondingDelegationEntry[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structUnbondingDelegation[]\",\"name\":\"unbondingResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"delegatorAddr\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorAddr\",\"type\":\"string\"}],\"name\":\"delegatorValidator\",\"outputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"operatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"consensusPubkey\",\"type\":\"string\"},{\"internalType\":\"bool\",\"name\":\"jailed\",\"type\":\"bool\"},{\"internalType\":\"enumBondStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"tokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delegatorShares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"internalType\":\"int64\",\"name\":\"unbondingHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commissionRates\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"updateTime\",\"type\":\"uint256\"}],\"internalType\":\"structCommission\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"},{\"internalType\":\"uint64[]\",\"name\":\"unbondingIds\",\"type\":\"uint64[]\"}],\"internalType\":\"structValidator\",\"name\":\"validator\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"delegatorAddr\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"delegatorValidators\",\"outputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"operatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"consensusPubkey\",\"type\":\"string\"},{\"internalType\":\"bool\",\"name\":\"jailed\",\"type\":\"bool\"},{\"internalType\":\"enumBondStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"tokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delegatorShares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"internalType\":\"int64\",\"name\":\"unbondingHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commissionRates\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"updateTime\",\"type\":\"uint256\"}],\"internalType\":\"structCommission\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"},{\"internalType\":\"uint64[]\",\"name\":\"unbondingIds\",\"type\":\"uint64[]\"}],\"internalType\":\"structValidator[]\",\"name\":\"validators\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"isNull\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"internalType\":\"structNullableUint\",\"name\":\"commissionRate\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"isNull\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"internalType\":\"structNullableUint\",\"name\":\"minSelfDelegation\",\"type\":\"tuple\"}],\"name\":\"editValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"params\",\"outputs\":[{\"components\":[{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"internalType\":\"uint32\",\"name\":\"maxValidators\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"maxEntries\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"historicalEntries\",\"type\":\"uint32\"},{\"internalType\":\"string\",\"name\":\"bondDenom\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"minCommissionRate\",\"type\":\"uint256\"}],\"internalType\":\"structParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pool\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"notBondedTokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"bondedTokens\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"delegatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"srcValidatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"dstValidatorAddress\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pageRequest\",\"type\":\"tuple\"}],\"name\":\"redelegations\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"delegatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorSrcAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorDstAddress\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"sharesDst\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structRedelegationEntry[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structRedelegation\",\"name\":\"redelegation\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"sharesDst\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structRedelegationEntry\",\"name\":\"redelegationEntry\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"internalType\":\"structRedelegationEntryResponse[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structRedelegationResponse[]\",\"name\":\"redelegationResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"delegatorAddr\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorAddr\",\"type\":\"string\"}],\"name\":\"unbondingDelegation\",\"outputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"delegatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structUnbondingDelegationEntry[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structUnbondingDelegation\",\"name\":\"unbond\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"undelegate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"}],\"name\":\"validator\",\"outputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"operatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"consensusPubkey\",\"type\":\"string\"},{\"internalType\":\"bool\",\"name\":\"jailed\",\"type\":\"bool\"},{\"internalType\":\"enumBondStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"tokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delegatorShares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"internalType\":\"int64\",\"name\":\"unbondingHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commissionRates\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"updateTime\",\"type\":\"uint256\"}],\"internalType\":\"structCommission\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"},{\"internalType\":\"uint64[]\",\"name\":\"unbondingIds\",\"type\":\"uint64[]\"}],\"internalType\":\"structValidator\",\"name\":\"validator\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"validatorAddr\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"validatorDelegations\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"delegatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"internalType\":\"structDelegation\",\"name\":\"delegation\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"internalType\":\"structDelegationResponse[]\",\"name\":\"delegationResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"validatorAddr\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"validatorUnbondingDelegations\",\"outputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"delegatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"validatorAddress\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structUnbondingDelegationEntry[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structUnbondingDelegation[]\",\"name\":\"unbondingResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"status\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"validators\",\"outputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"operatorAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"consensusPubkey\",\"type\":\"string\"},{\"internalType\":\"bool\",\"name\":\"jailed\",\"type\":\"bool\"},{\"internalType\":\"enumBondStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"tokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delegatorShares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"internalType\":\"int64\",\"name\":\"unbondingHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commissionRates\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"updateTime\",\"type\":\"uint256\"}],\"internalType\":\"structCommission\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"},{\"internalType\":\"uint64[]\",\"name\":\"unbondingIds\",\"type\":\"uint64[]\"}],\"internalType\":\"structValidator[]\",\"name\":\"validators\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorSrcAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorDstAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"beginRedelegate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"}],\"name\":\"cancelUnbondingDelegation\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"pubkey\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"createValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"delegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatorAddr\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddr\",\"type\":\"address\"}],\"name\":\"delegation\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"internalType\":\"structDelegation\",\"name\":\"delegation\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatorAddr\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"delegatorDelegations\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"internalType\":\"structDelegation\",\"name\":\"delegation\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"internalType\":\"structDelegationResponse[]\",\"name\":\"delegationResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatorAddr\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"delegatorUnbondingDelegations\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structUnbondingDelegationEntry[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structUnbondingDelegation[]\",\"name\":\"unbondingResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatorAddr\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddr\",\"type\":\"address\"}],\"name\":\"delegatorValidator\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"consensusPubkey\",\"type\":\"string\"},{\"internalType\":\"bool\",\"name\":\"jailed\",\"type\":\"bool\"},{\"internalType\":\"enumBondStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"tokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delegatorShares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"internalType\":\"int64\",\"name\":\"unbondingHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commissionRates\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"updateTime\",\"type\":\"uint256\"}],\"internalType\":\"structCommission\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"},{\"internalType\":\"uint64[]\",\"name\":\"unbondingIds\",\"type\":\"uint64[]\"}],\"internalType\":\"structValidator\",\"name\":\"validator\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatorAddr\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"delegatorValidators\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"consensusPubkey\",\"type\":\"string\"},{\"internalType\":\"bool\",\"name\":\"jailed\",\"type\":\"bool\"},{\"internalType\":\"enumBondStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"tokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delegatorShares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"internalType\":\"int64\",\"name\":\"unbondingHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commissionRates\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"updateTime\",\"type\":\"uint256\"}],\"internalType\":\"structCommission\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"},{\"internalType\":\"uint64[]\",\"name\":\"unbondingIds\",\"type\":\"uint64[]\"}],\"internalType\":\"structValidator[]\",\"name\":\"validators\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"isNull\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"internalType\":\"structNullableUint\",\"name\":\"commissionRate\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"bool\",\"name\":\"isNull\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"internalType\":\"structNullableUint\",\"name\":\"minSelfDelegation\",\"type\":\"tuple\"}],\"name\":\"editValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"params\",\"outputs\":[{\"components\":[{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"internalType\":\"uint32\",\"name\":\"maxValidators\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"maxEntries\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"historicalEntries\",\"type\":\"uint32\"},{\"internalType\":\"string\",\"name\":\"bondDenom\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"minCommissionRate\",\"type\":\"uint256\"}],\"internalType\":\"structParams\",\"name\":\"params\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pool\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"notBondedTokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"bondedTokens\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"srcValidatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"dstValidatorAddress\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pageRequest\",\"type\":\"tuple\"}],\"name\":\"redelegations\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorSrcAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorDstAddress\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"sharesDst\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structRedelegationEntry[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structRedelegation\",\"name\":\"redelegation\",\"type\":\"tuple\"},{\"components\":[{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"sharesDst\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structRedelegationEntry\",\"name\":\"redelegationEntry\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"internalType\":\"structRedelegationEntryResponse[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structRedelegationResponse[]\",\"name\":\"redelegationResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatorAddr\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddr\",\"type\":\"address\"}],\"name\":\"unbondingDelegation\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structUnbondingDelegationEntry[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structUnbondingDelegation\",\"name\":\"unbond\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"undelegate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"}],\"name\":\"validator\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"consensusPubkey\",\"type\":\"string\"},{\"internalType\":\"bool\",\"name\":\"jailed\",\"type\":\"bool\"},{\"internalType\":\"enumBondStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"tokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delegatorShares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"internalType\":\"int64\",\"name\":\"unbondingHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commissionRates\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"updateTime\",\"type\":\"uint256\"}],\"internalType\":\"structCommission\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"},{\"internalType\":\"uint64[]\",\"name\":\"unbondingIds\",\"type\":\"uint64[]\"}],\"internalType\":\"structValidator\",\"name\":\"validator\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddr\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"validatorDelegations\",\"outputs\":[{\"components\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"internalType\":\"structDelegation\",\"name\":\"delegation\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"internalType\":\"structDelegationResponse[]\",\"name\":\"delegationResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddr\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"validatorUnbondingDelegations\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"int64\",\"name\":\"creationHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"completionTime\",\"type\":\"int64\"},{\"internalType\":\"uint256\",\"name\":\"initialBalance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"unbondingId\",\"type\":\"uint64\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"}],\"internalType\":\"structUnbondingDelegationEntry[]\",\"name\":\"entries\",\"type\":\"tuple[]\"}],\"internalType\":\"structUnbondingDelegation[]\",\"name\":\"unbondingResponses\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"status\",\"type\":\"string\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"key\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offset\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"limit\",\"type\":\"uint64\"},{\"internalType\":\"bool\",\"name\":\"countTotal\",\"type\":\"bool\"},{\"internalType\":\"bool\",\"name\":\"reverse\",\"type\":\"bool\"}],\"internalType\":\"structPageRequest\",\"name\":\"pagination\",\"type\":\"tuple\"}],\"name\":\"validators\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"},{\"internalType\":\"string\",\"name\":\"consensusPubkey\",\"type\":\"string\"},{\"internalType\":\"bool\",\"name\":\"jailed\",\"type\":\"bool\"},{\"internalType\":\"enumBondStatus\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"tokens\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delegatorShares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"internalType\":\"int64\",\"name\":\"unbondingHeight\",\"type\":\"int64\"},{\"internalType\":\"int64\",\"name\":\"unbondingTime\",\"type\":\"int64\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commissionRates\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"updateTime\",\"type\":\"uint256\"}],\"internalType\":\"structCommission\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"int64\",\"name\":\"unbondingOnHoldRefCount\",\"type\":\"int64\"},{\"internalType\":\"uint64[]\",\"name\":\"unbondingIds\",\"type\":\"uint64[]\"}],\"internalType\":\"structValidator[]\",\"name\":\"validators\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"bytes\",\"name\":\"nextKey\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"total\",\"type\":\"uint64\"}],\"internalType\":\"structPageResponse\",\"name\":\"paginationResult\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
 }
 
 // StakingABI is the input ABI used to generate the binding from.
@@ -179,10 +179,10 @@ func (_Staking *StakingTransactorRaw) Transact(opts *bind.TransactOpts, method s
 	return _Staking.Contract.contract.Transact(opts, method, params...)
 }
 
-// Delegation is a free data retrieval call binding the contract method 0x25b8eda2.
+// Delegation is a free data retrieval call binding the contract method 0x046d3307.
 //
-// Solidity: function delegation(string delegatorAddr, string validatorAddr) view returns((string,string,uint256) delegation, uint256 balance)
-func (_Staking *StakingCaller) Delegation(opts *bind.CallOpts, delegatorAddr string, validatorAddr string) (struct {
+// Solidity: function delegation(address delegatorAddr, address validatorAddr) view returns((address,address,uint256) delegation, uint256 balance)
+func (_Staking *StakingCaller) Delegation(opts *bind.CallOpts, delegatorAddr common.Address, validatorAddr common.Address) (struct {
 	Delegation Delegation
 	Balance    *big.Int
 }, error) {
@@ -204,30 +204,30 @@ func (_Staking *StakingCaller) Delegation(opts *bind.CallOpts, delegatorAddr str
 
 }
 
-// Delegation is a free data retrieval call binding the contract method 0x25b8eda2.
+// Delegation is a free data retrieval call binding the contract method 0x046d3307.
 //
-// Solidity: function delegation(string delegatorAddr, string validatorAddr) view returns((string,string,uint256) delegation, uint256 balance)
-func (_Staking *StakingSession) Delegation(delegatorAddr string, validatorAddr string) (struct {
+// Solidity: function delegation(address delegatorAddr, address validatorAddr) view returns((address,address,uint256) delegation, uint256 balance)
+func (_Staking *StakingSession) Delegation(delegatorAddr common.Address, validatorAddr common.Address) (struct {
 	Delegation Delegation
 	Balance    *big.Int
 }, error) {
 	return _Staking.Contract.Delegation(&_Staking.CallOpts, delegatorAddr, validatorAddr)
 }
 
-// Delegation is a free data retrieval call binding the contract method 0x25b8eda2.
+// Delegation is a free data retrieval call binding the contract method 0x046d3307.
 //
-// Solidity: function delegation(string delegatorAddr, string validatorAddr) view returns((string,string,uint256) delegation, uint256 balance)
-func (_Staking *StakingCallerSession) Delegation(delegatorAddr string, validatorAddr string) (struct {
+// Solidity: function delegation(address delegatorAddr, address validatorAddr) view returns((address,address,uint256) delegation, uint256 balance)
+func (_Staking *StakingCallerSession) Delegation(delegatorAddr common.Address, validatorAddr common.Address) (struct {
 	Delegation Delegation
 	Balance    *big.Int
 }, error) {
 	return _Staking.Contract.Delegation(&_Staking.CallOpts, delegatorAddr, validatorAddr)
 }
 
-// DelegatorDelegations is a free data retrieval call binding the contract method 0x062cac23.
+// DelegatorDelegations is a free data retrieval call binding the contract method 0x256bd907.
 //
-// Solidity: function delegatorDelegations(string delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((string,string,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCaller) DelegatorDelegations(opts *bind.CallOpts, delegatorAddr string, pagination PageRequest) (struct {
+// Solidity: function delegatorDelegations(address delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((address,address,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCaller) DelegatorDelegations(opts *bind.CallOpts, delegatorAddr common.Address, pagination PageRequest) (struct {
 	DelegationResponses []DelegationResponse
 	PaginationResult    PageResponse
 }, error) {
@@ -249,30 +249,30 @@ func (_Staking *StakingCaller) DelegatorDelegations(opts *bind.CallOpts, delegat
 
 }
 
-// DelegatorDelegations is a free data retrieval call binding the contract method 0x062cac23.
+// DelegatorDelegations is a free data retrieval call binding the contract method 0x256bd907.
 //
-// Solidity: function delegatorDelegations(string delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((string,string,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingSession) DelegatorDelegations(delegatorAddr string, pagination PageRequest) (struct {
+// Solidity: function delegatorDelegations(address delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((address,address,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingSession) DelegatorDelegations(delegatorAddr common.Address, pagination PageRequest) (struct {
 	DelegationResponses []DelegationResponse
 	PaginationResult    PageResponse
 }, error) {
 	return _Staking.Contract.DelegatorDelegations(&_Staking.CallOpts, delegatorAddr, pagination)
 }
 
-// DelegatorDelegations is a free data retrieval call binding the contract method 0x062cac23.
+// DelegatorDelegations is a free data retrieval call binding the contract method 0x256bd907.
 //
-// Solidity: function delegatorDelegations(string delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((string,string,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCallerSession) DelegatorDelegations(delegatorAddr string, pagination PageRequest) (struct {
+// Solidity: function delegatorDelegations(address delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((address,address,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCallerSession) DelegatorDelegations(delegatorAddr common.Address, pagination PageRequest) (struct {
 	DelegationResponses []DelegationResponse
 	PaginationResult    PageResponse
 }, error) {
 	return _Staking.Contract.DelegatorDelegations(&_Staking.CallOpts, delegatorAddr, pagination)
 }
 
-// DelegatorUnbondingDelegations is a free data retrieval call binding the contract method 0xba157bc5.
+// DelegatorUnbondingDelegations is a free data retrieval call binding the contract method 0x155fd3ff.
 //
-// Solidity: function delegatorUnbondingDelegations(string delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCaller) DelegatorUnbondingDelegations(opts *bind.CallOpts, delegatorAddr string, pagination PageRequest) (struct {
+// Solidity: function delegatorUnbondingDelegations(address delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,address,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCaller) DelegatorUnbondingDelegations(opts *bind.CallOpts, delegatorAddr common.Address, pagination PageRequest) (struct {
 	UnbondingResponses []UnbondingDelegation
 	PaginationResult   PageResponse
 }, error) {
@@ -294,30 +294,30 @@ func (_Staking *StakingCaller) DelegatorUnbondingDelegations(opts *bind.CallOpts
 
 }
 
-// DelegatorUnbondingDelegations is a free data retrieval call binding the contract method 0xba157bc5.
+// DelegatorUnbondingDelegations is a free data retrieval call binding the contract method 0x155fd3ff.
 //
-// Solidity: function delegatorUnbondingDelegations(string delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingSession) DelegatorUnbondingDelegations(delegatorAddr string, pagination PageRequest) (struct {
+// Solidity: function delegatorUnbondingDelegations(address delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,address,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingSession) DelegatorUnbondingDelegations(delegatorAddr common.Address, pagination PageRequest) (struct {
 	UnbondingResponses []UnbondingDelegation
 	PaginationResult   PageResponse
 }, error) {
 	return _Staking.Contract.DelegatorUnbondingDelegations(&_Staking.CallOpts, delegatorAddr, pagination)
 }
 
-// DelegatorUnbondingDelegations is a free data retrieval call binding the contract method 0xba157bc5.
+// DelegatorUnbondingDelegations is a free data retrieval call binding the contract method 0x155fd3ff.
 //
-// Solidity: function delegatorUnbondingDelegations(string delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCallerSession) DelegatorUnbondingDelegations(delegatorAddr string, pagination PageRequest) (struct {
+// Solidity: function delegatorUnbondingDelegations(address delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,address,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCallerSession) DelegatorUnbondingDelegations(delegatorAddr common.Address, pagination PageRequest) (struct {
 	UnbondingResponses []UnbondingDelegation
 	PaginationResult   PageResponse
 }, error) {
 	return _Staking.Contract.DelegatorUnbondingDelegations(&_Staking.CallOpts, delegatorAddr, pagination)
 }
 
-// DelegatorValidator is a free data retrieval call binding the contract method 0x4118fcc0.
+// DelegatorValidator is a free data retrieval call binding the contract method 0x77007d17.
 //
-// Solidity: function delegatorValidator(string delegatorAddr, string validatorAddr) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
-func (_Staking *StakingCaller) DelegatorValidator(opts *bind.CallOpts, delegatorAddr string, validatorAddr string) (Validator, error) {
+// Solidity: function delegatorValidator(address delegatorAddr, address validatorAddr) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
+func (_Staking *StakingCaller) DelegatorValidator(opts *bind.CallOpts, delegatorAddr common.Address, validatorAddr common.Address) (Validator, error) {
 	var out []interface{}
 	err := _Staking.contract.Call(opts, &out, "delegatorValidator", delegatorAddr, validatorAddr)
 
@@ -331,24 +331,24 @@ func (_Staking *StakingCaller) DelegatorValidator(opts *bind.CallOpts, delegator
 
 }
 
-// DelegatorValidator is a free data retrieval call binding the contract method 0x4118fcc0.
+// DelegatorValidator is a free data retrieval call binding the contract method 0x77007d17.
 //
-// Solidity: function delegatorValidator(string delegatorAddr, string validatorAddr) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
-func (_Staking *StakingSession) DelegatorValidator(delegatorAddr string, validatorAddr string) (Validator, error) {
+// Solidity: function delegatorValidator(address delegatorAddr, address validatorAddr) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
+func (_Staking *StakingSession) DelegatorValidator(delegatorAddr common.Address, validatorAddr common.Address) (Validator, error) {
 	return _Staking.Contract.DelegatorValidator(&_Staking.CallOpts, delegatorAddr, validatorAddr)
 }
 
-// DelegatorValidator is a free data retrieval call binding the contract method 0x4118fcc0.
+// DelegatorValidator is a free data retrieval call binding the contract method 0x77007d17.
 //
-// Solidity: function delegatorValidator(string delegatorAddr, string validatorAddr) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
-func (_Staking *StakingCallerSession) DelegatorValidator(delegatorAddr string, validatorAddr string) (Validator, error) {
+// Solidity: function delegatorValidator(address delegatorAddr, address validatorAddr) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
+func (_Staking *StakingCallerSession) DelegatorValidator(delegatorAddr common.Address, validatorAddr common.Address) (Validator, error) {
 	return _Staking.Contract.DelegatorValidator(&_Staking.CallOpts, delegatorAddr, validatorAddr)
 }
 
-// DelegatorValidators is a free data retrieval call binding the contract method 0x0d4d2384.
+// DelegatorValidators is a free data retrieval call binding the contract method 0xe8e4fe99.
 //
-// Solidity: function delegatorValidators(string delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
-func (_Staking *StakingCaller) DelegatorValidators(opts *bind.CallOpts, delegatorAddr string, pagination PageRequest) (struct {
+// Solidity: function delegatorValidators(address delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
+func (_Staking *StakingCaller) DelegatorValidators(opts *bind.CallOpts, delegatorAddr common.Address, pagination PageRequest) (struct {
 	Validators       []Validator
 	PaginationResult PageResponse
 }, error) {
@@ -370,20 +370,20 @@ func (_Staking *StakingCaller) DelegatorValidators(opts *bind.CallOpts, delegato
 
 }
 
-// DelegatorValidators is a free data retrieval call binding the contract method 0x0d4d2384.
+// DelegatorValidators is a free data retrieval call binding the contract method 0xe8e4fe99.
 //
-// Solidity: function delegatorValidators(string delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
-func (_Staking *StakingSession) DelegatorValidators(delegatorAddr string, pagination PageRequest) (struct {
+// Solidity: function delegatorValidators(address delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
+func (_Staking *StakingSession) DelegatorValidators(delegatorAddr common.Address, pagination PageRequest) (struct {
 	Validators       []Validator
 	PaginationResult PageResponse
 }, error) {
 	return _Staking.Contract.DelegatorValidators(&_Staking.CallOpts, delegatorAddr, pagination)
 }
 
-// DelegatorValidators is a free data retrieval call binding the contract method 0x0d4d2384.
+// DelegatorValidators is a free data retrieval call binding the contract method 0xe8e4fe99.
 //
-// Solidity: function delegatorValidators(string delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
-func (_Staking *StakingCallerSession) DelegatorValidators(delegatorAddr string, pagination PageRequest) (struct {
+// Solidity: function delegatorValidators(address delegatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
+func (_Staking *StakingCallerSession) DelegatorValidators(delegatorAddr common.Address, pagination PageRequest) (struct {
 	Validators       []Validator
 	PaginationResult PageResponse
 }, error) {
@@ -466,10 +466,10 @@ func (_Staking *StakingCallerSession) Pool() (struct {
 	return _Staking.Contract.Pool(&_Staking.CallOpts)
 }
 
-// Redelegations is a free data retrieval call binding the contract method 0xe4227092.
+// Redelegations is a free data retrieval call binding the contract method 0xeb5643a9.
 //
-// Solidity: function redelegations(string delegatorAddress, string srcValidatorAddress, string dstValidatorAddress, (bytes,uint64,uint64,bool,bool) pageRequest) view returns(((string,string,string,(int64,int64,uint256,uint256,uint64,int64)[]),((int64,int64,uint256,uint256,uint64,int64),uint256)[])[] redelegationResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCaller) Redelegations(opts *bind.CallOpts, delegatorAddress string, srcValidatorAddress string, dstValidatorAddress string, pageRequest PageRequest) (struct {
+// Solidity: function redelegations(address delegatorAddress, address srcValidatorAddress, address dstValidatorAddress, (bytes,uint64,uint64,bool,bool) pageRequest) view returns(((address,address,address,(int64,int64,uint256,uint256,uint64,int64)[]),((int64,int64,uint256,uint256,uint64,int64),uint256)[])[] redelegationResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCaller) Redelegations(opts *bind.CallOpts, delegatorAddress common.Address, srcValidatorAddress common.Address, dstValidatorAddress common.Address, pageRequest PageRequest) (struct {
 	RedelegationResponses []RedelegationResponse
 	PaginationResult      PageResponse
 }, error) {
@@ -491,30 +491,30 @@ func (_Staking *StakingCaller) Redelegations(opts *bind.CallOpts, delegatorAddre
 
 }
 
-// Redelegations is a free data retrieval call binding the contract method 0xe4227092.
+// Redelegations is a free data retrieval call binding the contract method 0xeb5643a9.
 //
-// Solidity: function redelegations(string delegatorAddress, string srcValidatorAddress, string dstValidatorAddress, (bytes,uint64,uint64,bool,bool) pageRequest) view returns(((string,string,string,(int64,int64,uint256,uint256,uint64,int64)[]),((int64,int64,uint256,uint256,uint64,int64),uint256)[])[] redelegationResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingSession) Redelegations(delegatorAddress string, srcValidatorAddress string, dstValidatorAddress string, pageRequest PageRequest) (struct {
+// Solidity: function redelegations(address delegatorAddress, address srcValidatorAddress, address dstValidatorAddress, (bytes,uint64,uint64,bool,bool) pageRequest) view returns(((address,address,address,(int64,int64,uint256,uint256,uint64,int64)[]),((int64,int64,uint256,uint256,uint64,int64),uint256)[])[] redelegationResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingSession) Redelegations(delegatorAddress common.Address, srcValidatorAddress common.Address, dstValidatorAddress common.Address, pageRequest PageRequest) (struct {
 	RedelegationResponses []RedelegationResponse
 	PaginationResult      PageResponse
 }, error) {
 	return _Staking.Contract.Redelegations(&_Staking.CallOpts, delegatorAddress, srcValidatorAddress, dstValidatorAddress, pageRequest)
 }
 
-// Redelegations is a free data retrieval call binding the contract method 0xe4227092.
+// Redelegations is a free data retrieval call binding the contract method 0xeb5643a9.
 //
-// Solidity: function redelegations(string delegatorAddress, string srcValidatorAddress, string dstValidatorAddress, (bytes,uint64,uint64,bool,bool) pageRequest) view returns(((string,string,string,(int64,int64,uint256,uint256,uint64,int64)[]),((int64,int64,uint256,uint256,uint64,int64),uint256)[])[] redelegationResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCallerSession) Redelegations(delegatorAddress string, srcValidatorAddress string, dstValidatorAddress string, pageRequest PageRequest) (struct {
+// Solidity: function redelegations(address delegatorAddress, address srcValidatorAddress, address dstValidatorAddress, (bytes,uint64,uint64,bool,bool) pageRequest) view returns(((address,address,address,(int64,int64,uint256,uint256,uint64,int64)[]),((int64,int64,uint256,uint256,uint64,int64),uint256)[])[] redelegationResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCallerSession) Redelegations(delegatorAddress common.Address, srcValidatorAddress common.Address, dstValidatorAddress common.Address, pageRequest PageRequest) (struct {
 	RedelegationResponses []RedelegationResponse
 	PaginationResult      PageResponse
 }, error) {
 	return _Staking.Contract.Redelegations(&_Staking.CallOpts, delegatorAddress, srcValidatorAddress, dstValidatorAddress, pageRequest)
 }
 
-// UnbondingDelegation is a free data retrieval call binding the contract method 0x20bc02be.
+// UnbondingDelegation is a free data retrieval call binding the contract method 0x97e41907.
 //
-// Solidity: function unbondingDelegation(string delegatorAddr, string validatorAddr) view returns((string,string,(int64,int64,uint256,uint256,uint64,int64)[]) unbond)
-func (_Staking *StakingCaller) UnbondingDelegation(opts *bind.CallOpts, delegatorAddr string, validatorAddr string) (UnbondingDelegation, error) {
+// Solidity: function unbondingDelegation(address delegatorAddr, address validatorAddr) view returns((address,address,(int64,int64,uint256,uint256,uint64,int64)[]) unbond)
+func (_Staking *StakingCaller) UnbondingDelegation(opts *bind.CallOpts, delegatorAddr common.Address, validatorAddr common.Address) (UnbondingDelegation, error) {
 	var out []interface{}
 	err := _Staking.contract.Call(opts, &out, "unbondingDelegation", delegatorAddr, validatorAddr)
 
@@ -528,24 +528,24 @@ func (_Staking *StakingCaller) UnbondingDelegation(opts *bind.CallOpts, delegato
 
 }
 
-// UnbondingDelegation is a free data retrieval call binding the contract method 0x20bc02be.
+// UnbondingDelegation is a free data retrieval call binding the contract method 0x97e41907.
 //
-// Solidity: function unbondingDelegation(string delegatorAddr, string validatorAddr) view returns((string,string,(int64,int64,uint256,uint256,uint64,int64)[]) unbond)
-func (_Staking *StakingSession) UnbondingDelegation(delegatorAddr string, validatorAddr string) (UnbondingDelegation, error) {
+// Solidity: function unbondingDelegation(address delegatorAddr, address validatorAddr) view returns((address,address,(int64,int64,uint256,uint256,uint64,int64)[]) unbond)
+func (_Staking *StakingSession) UnbondingDelegation(delegatorAddr common.Address, validatorAddr common.Address) (UnbondingDelegation, error) {
 	return _Staking.Contract.UnbondingDelegation(&_Staking.CallOpts, delegatorAddr, validatorAddr)
 }
 
-// UnbondingDelegation is a free data retrieval call binding the contract method 0x20bc02be.
+// UnbondingDelegation is a free data retrieval call binding the contract method 0x97e41907.
 //
-// Solidity: function unbondingDelegation(string delegatorAddr, string validatorAddr) view returns((string,string,(int64,int64,uint256,uint256,uint64,int64)[]) unbond)
-func (_Staking *StakingCallerSession) UnbondingDelegation(delegatorAddr string, validatorAddr string) (UnbondingDelegation, error) {
+// Solidity: function unbondingDelegation(address delegatorAddr, address validatorAddr) view returns((address,address,(int64,int64,uint256,uint256,uint64,int64)[]) unbond)
+func (_Staking *StakingCallerSession) UnbondingDelegation(delegatorAddr common.Address, validatorAddr common.Address) (UnbondingDelegation, error) {
 	return _Staking.Contract.UnbondingDelegation(&_Staking.CallOpts, delegatorAddr, validatorAddr)
 }
 
-// Validator is a free data retrieval call binding the contract method 0x0bc82a17.
+// Validator is a free data retrieval call binding the contract method 0x223b3b7a.
 //
-// Solidity: function validator(string validatorAddress) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
-func (_Staking *StakingCaller) Validator(opts *bind.CallOpts, validatorAddress string) (Validator, error) {
+// Solidity: function validator(address validatorAddress) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
+func (_Staking *StakingCaller) Validator(opts *bind.CallOpts, validatorAddress common.Address) (Validator, error) {
 	var out []interface{}
 	err := _Staking.contract.Call(opts, &out, "validator", validatorAddress)
 
@@ -559,24 +559,24 @@ func (_Staking *StakingCaller) Validator(opts *bind.CallOpts, validatorAddress s
 
 }
 
-// Validator is a free data retrieval call binding the contract method 0x0bc82a17.
+// Validator is a free data retrieval call binding the contract method 0x223b3b7a.
 //
-// Solidity: function validator(string validatorAddress) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
-func (_Staking *StakingSession) Validator(validatorAddress string) (Validator, error) {
+// Solidity: function validator(address validatorAddress) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
+func (_Staking *StakingSession) Validator(validatorAddress common.Address) (Validator, error) {
 	return _Staking.Contract.Validator(&_Staking.CallOpts, validatorAddress)
 }
 
-// Validator is a free data retrieval call binding the contract method 0x0bc82a17.
+// Validator is a free data retrieval call binding the contract method 0x223b3b7a.
 //
-// Solidity: function validator(string validatorAddress) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
-func (_Staking *StakingCallerSession) Validator(validatorAddress string) (Validator, error) {
+// Solidity: function validator(address validatorAddress) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[]) validator)
+func (_Staking *StakingCallerSession) Validator(validatorAddress common.Address) (Validator, error) {
 	return _Staking.Contract.Validator(&_Staking.CallOpts, validatorAddress)
 }
 
-// ValidatorDelegations is a free data retrieval call binding the contract method 0x85cadbda.
+// ValidatorDelegations is a free data retrieval call binding the contract method 0xc89017cd.
 //
-// Solidity: function validatorDelegations(string validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((string,string,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCaller) ValidatorDelegations(opts *bind.CallOpts, validatorAddr string, pagination PageRequest) (struct {
+// Solidity: function validatorDelegations(address validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((address,address,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCaller) ValidatorDelegations(opts *bind.CallOpts, validatorAddr common.Address, pagination PageRequest) (struct {
 	DelegationResponses []DelegationResponse
 	PaginationResult    PageResponse
 }, error) {
@@ -598,30 +598,30 @@ func (_Staking *StakingCaller) ValidatorDelegations(opts *bind.CallOpts, validat
 
 }
 
-// ValidatorDelegations is a free data retrieval call binding the contract method 0x85cadbda.
+// ValidatorDelegations is a free data retrieval call binding the contract method 0xc89017cd.
 //
-// Solidity: function validatorDelegations(string validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((string,string,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingSession) ValidatorDelegations(validatorAddr string, pagination PageRequest) (struct {
+// Solidity: function validatorDelegations(address validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((address,address,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingSession) ValidatorDelegations(validatorAddr common.Address, pagination PageRequest) (struct {
 	DelegationResponses []DelegationResponse
 	PaginationResult    PageResponse
 }, error) {
 	return _Staking.Contract.ValidatorDelegations(&_Staking.CallOpts, validatorAddr, pagination)
 }
 
-// ValidatorDelegations is a free data retrieval call binding the contract method 0x85cadbda.
+// ValidatorDelegations is a free data retrieval call binding the contract method 0xc89017cd.
 //
-// Solidity: function validatorDelegations(string validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((string,string,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCallerSession) ValidatorDelegations(validatorAddr string, pagination PageRequest) (struct {
+// Solidity: function validatorDelegations(address validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns(((address,address,uint256),uint256)[] delegationResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCallerSession) ValidatorDelegations(validatorAddr common.Address, pagination PageRequest) (struct {
 	DelegationResponses []DelegationResponse
 	PaginationResult    PageResponse
 }, error) {
 	return _Staking.Contract.ValidatorDelegations(&_Staking.CallOpts, validatorAddr, pagination)
 }
 
-// ValidatorUnbondingDelegations is a free data retrieval call binding the contract method 0x1394d67f.
+// ValidatorUnbondingDelegations is a free data retrieval call binding the contract method 0x51b55195.
 //
-// Solidity: function validatorUnbondingDelegations(string validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCaller) ValidatorUnbondingDelegations(opts *bind.CallOpts, validatorAddr string, pagination PageRequest) (struct {
+// Solidity: function validatorUnbondingDelegations(address validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,address,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCaller) ValidatorUnbondingDelegations(opts *bind.CallOpts, validatorAddr common.Address, pagination PageRequest) (struct {
 	UnbondingResponses []UnbondingDelegation
 	PaginationResult   PageResponse
 }, error) {
@@ -643,20 +643,20 @@ func (_Staking *StakingCaller) ValidatorUnbondingDelegations(opts *bind.CallOpts
 
 }
 
-// ValidatorUnbondingDelegations is a free data retrieval call binding the contract method 0x1394d67f.
+// ValidatorUnbondingDelegations is a free data retrieval call binding the contract method 0x51b55195.
 //
-// Solidity: function validatorUnbondingDelegations(string validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingSession) ValidatorUnbondingDelegations(validatorAddr string, pagination PageRequest) (struct {
+// Solidity: function validatorUnbondingDelegations(address validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,address,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingSession) ValidatorUnbondingDelegations(validatorAddr common.Address, pagination PageRequest) (struct {
 	UnbondingResponses []UnbondingDelegation
 	PaginationResult   PageResponse
 }, error) {
 	return _Staking.Contract.ValidatorUnbondingDelegations(&_Staking.CallOpts, validatorAddr, pagination)
 }
 
-// ValidatorUnbondingDelegations is a free data retrieval call binding the contract method 0x1394d67f.
+// ValidatorUnbondingDelegations is a free data retrieval call binding the contract method 0x51b55195.
 //
-// Solidity: function validatorUnbondingDelegations(string validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
-func (_Staking *StakingCallerSession) ValidatorUnbondingDelegations(validatorAddr string, pagination PageRequest) (struct {
+// Solidity: function validatorUnbondingDelegations(address validatorAddr, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,address,(int64,int64,uint256,uint256,uint64,int64)[])[] unbondingResponses, (bytes,uint64) paginationResult)
+func (_Staking *StakingCallerSession) ValidatorUnbondingDelegations(validatorAddr common.Address, pagination PageRequest) (struct {
 	UnbondingResponses []UnbondingDelegation
 	PaginationResult   PageResponse
 }, error) {
@@ -665,7 +665,7 @@ func (_Staking *StakingCallerSession) ValidatorUnbondingDelegations(validatorAdd
 
 // Validators is a free data retrieval call binding the contract method 0x186b2167.
 //
-// Solidity: function validators(string status, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
+// Solidity: function validators(string status, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
 func (_Staking *StakingCaller) Validators(opts *bind.CallOpts, status string, pagination PageRequest) (struct {
 	Validators       []Validator
 	PaginationResult PageResponse
@@ -690,7 +690,7 @@ func (_Staking *StakingCaller) Validators(opts *bind.CallOpts, status string, pa
 
 // Validators is a free data retrieval call binding the contract method 0x186b2167.
 //
-// Solidity: function validators(string status, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
+// Solidity: function validators(string status, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
 func (_Staking *StakingSession) Validators(status string, pagination PageRequest) (struct {
 	Validators       []Validator
 	PaginationResult PageResponse
@@ -700,7 +700,7 @@ func (_Staking *StakingSession) Validators(status string, pagination PageRequest
 
 // Validators is a free data retrieval call binding the contract method 0x186b2167.
 //
-// Solidity: function validators(string status, (bytes,uint64,uint64,bool,bool) pagination) view returns((string,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
+// Solidity: function validators(string status, (bytes,uint64,uint64,bool,bool) pagination) view returns((address,string,bool,uint8,uint256,uint256,(string,string,string,string,string),int64,int64,((uint256,uint256,uint256),uint256),uint256,int64,uint64[])[] validators, (bytes,uint64) paginationResult)
 func (_Staking *StakingCallerSession) Validators(status string, pagination PageRequest) (struct {
 	Validators       []Validator
 	PaginationResult PageResponse
@@ -708,45 +708,45 @@ func (_Staking *StakingCallerSession) Validators(status string, pagination PageR
 	return _Staking.Contract.Validators(&_Staking.CallOpts, status, pagination)
 }
 
-// BeginRedelegate is a paid mutator transaction binding the contract method 0x2e436cf2.
+// BeginRedelegate is a paid mutator transaction binding the contract method 0xb3a8ae3b.
 //
-// Solidity: function beginRedelegate(string validatorSrcAddress, string validatorDstAddress, uint256 amount) returns(uint256 completionTime)
-func (_Staking *StakingTransactor) BeginRedelegate(opts *bind.TransactOpts, validatorSrcAddress string, validatorDstAddress string, amount *big.Int) (*types.Transaction, error) {
+// Solidity: function beginRedelegate(address validatorSrcAddress, address validatorDstAddress, uint256 amount) returns(uint256 completionTime)
+func (_Staking *StakingTransactor) BeginRedelegate(opts *bind.TransactOpts, validatorSrcAddress common.Address, validatorDstAddress common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _Staking.contract.Transact(opts, "beginRedelegate", validatorSrcAddress, validatorDstAddress, amount)
 }
 
-// BeginRedelegate is a paid mutator transaction binding the contract method 0x2e436cf2.
+// BeginRedelegate is a paid mutator transaction binding the contract method 0xb3a8ae3b.
 //
-// Solidity: function beginRedelegate(string validatorSrcAddress, string validatorDstAddress, uint256 amount) returns(uint256 completionTime)
-func (_Staking *StakingSession) BeginRedelegate(validatorSrcAddress string, validatorDstAddress string, amount *big.Int) (*types.Transaction, error) {
+// Solidity: function beginRedelegate(address validatorSrcAddress, address validatorDstAddress, uint256 amount) returns(uint256 completionTime)
+func (_Staking *StakingSession) BeginRedelegate(validatorSrcAddress common.Address, validatorDstAddress common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _Staking.Contract.BeginRedelegate(&_Staking.TransactOpts, validatorSrcAddress, validatorDstAddress, amount)
 }
 
-// BeginRedelegate is a paid mutator transaction binding the contract method 0x2e436cf2.
+// BeginRedelegate is a paid mutator transaction binding the contract method 0xb3a8ae3b.
 //
-// Solidity: function beginRedelegate(string validatorSrcAddress, string validatorDstAddress, uint256 amount) returns(uint256 completionTime)
-func (_Staking *StakingTransactorSession) BeginRedelegate(validatorSrcAddress string, validatorDstAddress string, amount *big.Int) (*types.Transaction, error) {
+// Solidity: function beginRedelegate(address validatorSrcAddress, address validatorDstAddress, uint256 amount) returns(uint256 completionTime)
+func (_Staking *StakingTransactorSession) BeginRedelegate(validatorSrcAddress common.Address, validatorDstAddress common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _Staking.Contract.BeginRedelegate(&_Staking.TransactOpts, validatorSrcAddress, validatorDstAddress, amount)
 }
 
-// CancelUnbondingDelegation is a paid mutator transaction binding the contract method 0x43970281.
+// CancelUnbondingDelegation is a paid mutator transaction binding the contract method 0x50826aef.
 //
-// Solidity: function cancelUnbondingDelegation(string validatorAddress, uint256 amount, uint256 creationHeight) returns()
-func (_Staking *StakingTransactor) CancelUnbondingDelegation(opts *bind.TransactOpts, validatorAddress string, amount *big.Int, creationHeight *big.Int) (*types.Transaction, error) {
+// Solidity: function cancelUnbondingDelegation(address validatorAddress, uint256 amount, uint256 creationHeight) returns()
+func (_Staking *StakingTransactor) CancelUnbondingDelegation(opts *bind.TransactOpts, validatorAddress common.Address, amount *big.Int, creationHeight *big.Int) (*types.Transaction, error) {
 	return _Staking.contract.Transact(opts, "cancelUnbondingDelegation", validatorAddress, amount, creationHeight)
 }
 
-// CancelUnbondingDelegation is a paid mutator transaction binding the contract method 0x43970281.
+// CancelUnbondingDelegation is a paid mutator transaction binding the contract method 0x50826aef.
 //
-// Solidity: function cancelUnbondingDelegation(string validatorAddress, uint256 amount, uint256 creationHeight) returns()
-func (_Staking *StakingSession) CancelUnbondingDelegation(validatorAddress string, amount *big.Int, creationHeight *big.Int) (*types.Transaction, error) {
+// Solidity: function cancelUnbondingDelegation(address validatorAddress, uint256 amount, uint256 creationHeight) returns()
+func (_Staking *StakingSession) CancelUnbondingDelegation(validatorAddress common.Address, amount *big.Int, creationHeight *big.Int) (*types.Transaction, error) {
 	return _Staking.Contract.CancelUnbondingDelegation(&_Staking.TransactOpts, validatorAddress, amount, creationHeight)
 }
 
-// CancelUnbondingDelegation is a paid mutator transaction binding the contract method 0x43970281.
+// CancelUnbondingDelegation is a paid mutator transaction binding the contract method 0x50826aef.
 //
-// Solidity: function cancelUnbondingDelegation(string validatorAddress, uint256 amount, uint256 creationHeight) returns()
-func (_Staking *StakingTransactorSession) CancelUnbondingDelegation(validatorAddress string, amount *big.Int, creationHeight *big.Int) (*types.Transaction, error) {
+// Solidity: function cancelUnbondingDelegation(address validatorAddress, uint256 amount, uint256 creationHeight) returns()
+func (_Staking *StakingTransactorSession) CancelUnbondingDelegation(validatorAddress common.Address, amount *big.Int, creationHeight *big.Int) (*types.Transaction, error) {
 	return _Staking.Contract.CancelUnbondingDelegation(&_Staking.TransactOpts, validatorAddress, amount, creationHeight)
 }
 
@@ -771,24 +771,24 @@ func (_Staking *StakingTransactorSession) CreateValidator(description Descriptio
 	return _Staking.Contract.CreateValidator(&_Staking.TransactOpts, description, commission, minSelfDelegation, pubkey, value)
 }
 
-// Delegate is a paid mutator transaction binding the contract method 0x03f24de1.
+// Delegate is a paid mutator transaction binding the contract method 0x026e402b.
 //
-// Solidity: function delegate(string validatorAddress, uint256 amount) returns()
-func (_Staking *StakingTransactor) Delegate(opts *bind.TransactOpts, validatorAddress string, amount *big.Int) (*types.Transaction, error) {
+// Solidity: function delegate(address validatorAddress, uint256 amount) returns()
+func (_Staking *StakingTransactor) Delegate(opts *bind.TransactOpts, validatorAddress common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _Staking.contract.Transact(opts, "delegate", validatorAddress, amount)
 }
 
-// Delegate is a paid mutator transaction binding the contract method 0x03f24de1.
+// Delegate is a paid mutator transaction binding the contract method 0x026e402b.
 //
-// Solidity: function delegate(string validatorAddress, uint256 amount) returns()
-func (_Staking *StakingSession) Delegate(validatorAddress string, amount *big.Int) (*types.Transaction, error) {
+// Solidity: function delegate(address validatorAddress, uint256 amount) returns()
+func (_Staking *StakingSession) Delegate(validatorAddress common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _Staking.Contract.Delegate(&_Staking.TransactOpts, validatorAddress, amount)
 }
 
-// Delegate is a paid mutator transaction binding the contract method 0x03f24de1.
+// Delegate is a paid mutator transaction binding the contract method 0x026e402b.
 //
-// Solidity: function delegate(string validatorAddress, uint256 amount) returns()
-func (_Staking *StakingTransactorSession) Delegate(validatorAddress string, amount *big.Int) (*types.Transaction, error) {
+// Solidity: function delegate(address validatorAddress, uint256 amount) returns()
+func (_Staking *StakingTransactorSession) Delegate(validatorAddress common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _Staking.Contract.Delegate(&_Staking.TransactOpts, validatorAddress, amount)
 }
 
@@ -813,23 +813,23 @@ func (_Staking *StakingTransactorSession) EditValidator(description Description,
 	return _Staking.Contract.EditValidator(&_Staking.TransactOpts, description, commissionRate, minSelfDelegation)
 }
 
-// Undelegate is a paid mutator transaction binding the contract method 0x8dfc8897.
+// Undelegate is a paid mutator transaction binding the contract method 0x4d99dd16.
 //
-// Solidity: function undelegate(string validatorAddress, uint256 amount) returns(uint256 completionTime)
-func (_Staking *StakingTransactor) Undelegate(opts *bind.TransactOpts, validatorAddress string, amount *big.Int) (*types.Transaction, error) {
+// Solidity: function undelegate(address validatorAddress, uint256 amount) returns(uint256 completionTime)
+func (_Staking *StakingTransactor) Undelegate(opts *bind.TransactOpts, validatorAddress common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _Staking.contract.Transact(opts, "undelegate", validatorAddress, amount)
 }
 
-// Undelegate is a paid mutator transaction binding the contract method 0x8dfc8897.
+// Undelegate is a paid mutator transaction binding the contract method 0x4d99dd16.
 //
-// Solidity: function undelegate(string validatorAddress, uint256 amount) returns(uint256 completionTime)
-func (_Staking *StakingSession) Undelegate(validatorAddress string, amount *big.Int) (*types.Transaction, error) {
+// Solidity: function undelegate(address validatorAddress, uint256 amount) returns(uint256 completionTime)
+func (_Staking *StakingSession) Undelegate(validatorAddress common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _Staking.Contract.Undelegate(&_Staking.TransactOpts, validatorAddress, amount)
 }
 
-// Undelegate is a paid mutator transaction binding the contract method 0x8dfc8897.
+// Undelegate is a paid mutator transaction binding the contract method 0x4d99dd16.
 //
-// Solidity: function undelegate(string validatorAddress, uint256 amount) returns(uint256 completionTime)
-func (_Staking *StakingTransactorSession) Undelegate(validatorAddress string, amount *big.Int) (*types.Transaction, error) {
+// Solidity: function undelegate(address validatorAddress, uint256 amount) returns(uint256 completionTime)
+func (_Staking *StakingTransactorSession) Undelegate(validatorAddress common.Address, amount *big.Int) (*types.Transaction, error) {
 	return _Staking.Contract.Undelegate(&_Staking.TransactOpts, validatorAddress, amount)
 }

--- a/precompiles/staking/query.go
+++ b/precompiles/staking/query.go
@@ -19,7 +19,10 @@ func (s *StakingPrecompile) Validators(ctx sdk.Context, _ *vm.EVM, method *abi.M
 
 	validators := make([]Validator, len(response.Validators))
 	for i, v := range response.Validators {
-		validators[i] = convertValidator(v)
+		validators[i], err = convertValidator(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 	paginationResult := convertPageResponse(response.Pagination)
 
@@ -36,7 +39,12 @@ func (s *StakingPrecompile) Validator(ctx sdk.Context, _ *vm.EVM, method *abi.Me
 		return nil, err
 	}
 
-	return method.Outputs.Pack(convertValidator(response.Validator))
+	res, err := convertValidator(response.Validator)
+	if err != nil {
+		return nil, err
+	}
+
+	return method.Outputs.Pack(res)
 }
 
 func (s *StakingPrecompile) ValidatorDelegations(ctx sdk.Context, _ *vm.EVM, method *abi.Method, args []interface{}) ([]byte, error) {
@@ -51,7 +59,10 @@ func (s *StakingPrecompile) ValidatorDelegations(ctx sdk.Context, _ *vm.EVM, met
 
 	delegationResponses := make([]DelegationResponse, len(response.DelegationResponses))
 	for i, v := range response.DelegationResponses {
-		delegationResponses[i] = convertDelegationResponse(v)
+		delegationResponses[i], err = convertDelegationResponse(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 	paginationResult := convertPageResponse(response.Pagination)
 
@@ -70,7 +81,10 @@ func (s *StakingPrecompile) ValidatorUnbondingDelegations(ctx sdk.Context, _ *vm
 
 	unbondingResponses := make([]UnbondingDelegation, len(response.UnbondingResponses))
 	for i, v := range response.UnbondingResponses {
-		unbondingResponses[i] = convertUnbondingDelegation(v)
+		unbondingResponses[i], err = convertUnbondingDelegation(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 	paginationResult := convertPageResponse(response.Pagination)
 
@@ -86,7 +100,10 @@ func (s *StakingPrecompile) Delegation(ctx sdk.Context, _ *vm.EVM, method *abi.M
 	if err != nil {
 		return nil, err
 	}
-	delegation := convertDelegation(response.DelegationResponse.Delegation)
+	delegation, err := convertDelegation(response.DelegationResponse.Delegation)
+	if err != nil {
+		return nil, err
+	}
 	balance := response.DelegationResponse.Balance.Amount.BigInt()
 
 	return method.Outputs.Pack(delegation, balance)
@@ -102,7 +119,12 @@ func (s *StakingPrecompile) UnbondingDelegation(ctx sdk.Context, _ *vm.EVM, meth
 		return nil, err
 	}
 
-	return method.Outputs.Pack(convertUnbondingDelegation(response.Unbond))
+	res, err := convertUnbondingDelegation(response.Unbond)
+	if err != nil {
+		return nil, err
+	}
+
+	return method.Outputs.Pack(res)
 }
 
 func (s *StakingPrecompile) DelegatorDelegations(ctx sdk.Context, _ *vm.EVM, method *abi.Method, args []interface{}) ([]byte, error) {
@@ -117,7 +139,10 @@ func (s *StakingPrecompile) DelegatorDelegations(ctx sdk.Context, _ *vm.EVM, met
 
 	delegationResponses := make([]DelegationResponse, len(response.DelegationResponses))
 	for i, v := range response.DelegationResponses {
-		delegationResponses[i] = convertDelegationResponse(v)
+		delegationResponses[i], err = convertDelegationResponse(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 	paginationResult := convertPageResponse(response.Pagination)
 
@@ -136,7 +161,10 @@ func (s *StakingPrecompile) DelegatorUnbondingDelegations(ctx sdk.Context, _ *vm
 
 	unbondingResponses := make([]UnbondingDelegation, len(response.UnbondingResponses))
 	for i, v := range response.UnbondingResponses {
-		unbondingResponses[i] = convertUnbondingDelegation(v)
+		unbondingResponses[i], err = convertUnbondingDelegation(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 	paginationResult := convertPageResponse(response.Pagination)
 
@@ -155,7 +183,10 @@ func (s *StakingPrecompile) Redelegations(ctx sdk.Context, _ *vm.EVM, method *ab
 
 	redelegationResponses := make([]RedelegationResponse, len(response.RedelegationResponses))
 	for i, v := range response.RedelegationResponses {
-		redelegationResponses[i] = convertRedelegationResponse(v)
+		redelegationResponses[i], err = convertRedelegationResponse(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 	paginationResult := convertPageResponse(response.Pagination)
 
@@ -174,7 +205,10 @@ func (s *StakingPrecompile) DelegatorValidators(ctx sdk.Context, _ *vm.EVM, meth
 
 	validators := make([]Validator, len(response.Validators))
 	for i, v := range response.Validators {
-		validators[i] = convertValidator(v)
+		validators[i], err = convertValidator(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 	paginationResult := convertPageResponse(response.Pagination)
 
@@ -191,7 +225,12 @@ func (s *StakingPrecompile) DelegatorValidator(ctx sdk.Context, _ *vm.EVM, metho
 		return nil, err
 	}
 
-	return method.Outputs.Pack(convertValidator(response.Validator))
+	res, err := convertValidator(response.Validator)
+	if err != nil {
+		return nil, err
+	}
+
+	return method.Outputs.Pack(res)
 }
 
 func (s *StakingPrecompile) Pool(ctx sdk.Context, _ *vm.EVM, method *abi.Method, args []interface{}) ([]byte, error) {

--- a/precompiles/staking/query_test.go
+++ b/precompiles/staking/query_test.go
@@ -72,7 +72,7 @@ func (s *StakingTestSuite) TestValidator() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(operatorAddress string) []byte
+		malleate    func(operatorAddress common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -80,7 +80,7 @@ func (s *StakingTestSuite) TestValidator() {
 	}{
 		{
 			"success",
-			func(operatorAddress string) []byte {
+			func(operatorAddress common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					operatorAddress,
@@ -94,7 +94,7 @@ func (s *StakingTestSuite) TestValidator() {
 				operatorAddress, err := s.firstBondedValidator()
 				s.Require().NoError(err)
 				validator := out[0].(stakingprecompile.Validator)
-				s.Require().EqualValues(common.HexToAddress(validator.OperatorAddress), common.BytesToAddress(operatorAddress.Bytes()))
+				s.Require().EqualValues(validator.OperatorAddress, common.BytesToAddress(operatorAddress.Bytes()))
 			},
 			100000,
 			false,
@@ -108,7 +108,7 @@ func (s *StakingTestSuite) TestValidator() {
 			operatorAddress, err := s.firstBondedValidator()
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(operatorAddress.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(operatorAddress.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -127,7 +127,7 @@ func (s *StakingTestSuite) TestValidatorDelegations() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(operatorAddress string) []byte
+		malleate    func(operatorAddress common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -135,7 +135,7 @@ func (s *StakingTestSuite) TestValidatorDelegations() {
 	}{
 		{
 			"success",
-			func(operatorAddress string) []byte {
+			func(operatorAddress common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					operatorAddress,
@@ -170,7 +170,7 @@ func (s *StakingTestSuite) TestValidatorDelegations() {
 			operatorAddress, err := s.firstBondedValidator()
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(operatorAddress.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(operatorAddress.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -189,7 +189,7 @@ func (s *StakingTestSuite) TestValidatorUnbondingDelegations() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(operatorAddress string) []byte
+		malleate    func(operatorAddress common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -197,7 +197,7 @@ func (s *StakingTestSuite) TestValidatorUnbondingDelegations() {
 	}{
 		{
 			"success",
-			func(operatorAddress string) []byte {
+			func(operatorAddress common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					operatorAddress,
@@ -234,7 +234,7 @@ func (s *StakingTestSuite) TestValidatorUnbondingDelegations() {
 			_, err = s.stakingKeeper.Undelegate(s.Ctx, delAddr, operatorAddress, sdk.NewDec(1))
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(operatorAddress.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(operatorAddress.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -253,7 +253,7 @@ func (s *StakingTestSuite) TestDelegation() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(delAddr, valAddr string) []byte
+		malleate    func(delAddr, valAddr common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -261,7 +261,7 @@ func (s *StakingTestSuite) TestDelegation() {
 	}{
 		{
 			"success",
-			func(delAddr, valAddr string) []byte {
+			func(delAddr, valAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					delAddr,
@@ -298,7 +298,7 @@ func (s *StakingTestSuite) TestDelegation() {
 			delAddr, err := sdk.AccAddressFromBech32(d[0].DelegatorAddress)
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(delAddr.String(), operatorAddress.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(delAddr.Bytes()), common.Address(operatorAddress.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -317,7 +317,7 @@ func (s *StakingTestSuite) TestUnbondingDelegation() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(delAddr, valAddr string) []byte
+		malleate    func(delAddr, valAddr common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -325,7 +325,7 @@ func (s *StakingTestSuite) TestUnbondingDelegation() {
 	}{
 		{
 			"success",
-			func(delAddr, valAddr string) []byte {
+			func(delAddr, valAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					delAddr,
@@ -359,7 +359,7 @@ func (s *StakingTestSuite) TestUnbondingDelegation() {
 			_, err = s.stakingKeeper.Undelegate(s.Ctx, delAddr, operatorAddress, sdk.NewDec(1))
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(delAddr.String(), operatorAddress.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(delAddr.Bytes()), common.Address(operatorAddress.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -378,7 +378,7 @@ func (s *StakingTestSuite) TestDelegatorDelegations() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(delAddr string) []byte
+		malleate    func(delAddr common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -386,7 +386,7 @@ func (s *StakingTestSuite) TestDelegatorDelegations() {
 	}{
 		{
 			"success",
-			func(delAddr string) []byte {
+			func(delAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					delAddr,
@@ -423,7 +423,7 @@ func (s *StakingTestSuite) TestDelegatorDelegations() {
 			delAddr, err := sdk.AccAddressFromBech32(d[0].DelegatorAddress)
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(delAddr.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(delAddr.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -442,7 +442,7 @@ func (s *StakingTestSuite) TestDelegatorUnbondingDelegations() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(delAddr string) []byte
+		malleate    func(delAddr common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -450,7 +450,7 @@ func (s *StakingTestSuite) TestDelegatorUnbondingDelegations() {
 	}{
 		{
 			"success",
-			func(delAddr string) []byte {
+			func(delAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					delAddr,
@@ -489,7 +489,7 @@ func (s *StakingTestSuite) TestDelegatorUnbondingDelegations() {
 			_, err = s.stakingKeeper.Undelegate(s.Ctx, delAddr, operatorAddress, sdk.NewDec(1))
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(delAddr.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(delAddr.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -508,7 +508,7 @@ func (s *StakingTestSuite) TestRedelegations() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(delAddr, srcValAddr, dstValAddr string) []byte
+		malleate    func(delAddr, srcValAddr, dstValAddr common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -516,7 +516,7 @@ func (s *StakingTestSuite) TestRedelegations() {
 	}{
 		{
 			"success",
-			func(delAddr, srcValAddr, dstValAddr string) []byte {
+			func(delAddr, srcValAddr, dstValAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					delAddr,
@@ -559,7 +559,7 @@ func (s *StakingTestSuite) TestRedelegations() {
 			_, err = s.stakingKeeper.BeginRedelegation(s.Ctx, delAddr, operatorAddress, s.signerOne.ValAddr, sdk.NewDec(1))
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(delAddr.String(), operatorAddress.String(), s.signerOne.ValAddr.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(delAddr.Bytes()), common.Address(operatorAddress.Bytes()), common.Address(s.signerOne.ValAddr.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -578,7 +578,7 @@ func (s *StakingTestSuite) TestDelegatorValidators() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(delAddr string) []byte
+		malleate    func(delAddr common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -586,7 +586,7 @@ func (s *StakingTestSuite) TestDelegatorValidators() {
 	}{
 		{
 			"success",
-			func(delAddr string) []byte {
+			func(delAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					delAddr,
@@ -623,7 +623,7 @@ func (s *StakingTestSuite) TestDelegatorValidators() {
 			delAddr, err := sdk.AccAddressFromBech32(d[0].DelegatorAddress)
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(delAddr.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(delAddr.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -642,7 +642,7 @@ func (s *StakingTestSuite) TestDelegatorValidator() {
 
 	testCases := []struct {
 		name        string
-		malleate    func(delAddr, valAddr string) []byte
+		malleate    func(delAddr, valAddr common.Address) []byte
 		postCheck   func(bz []byte)
 		gas         uint64
 		expErr      bool
@@ -650,7 +650,7 @@ func (s *StakingTestSuite) TestDelegatorValidator() {
 	}{
 		{
 			"success",
-			func(delAddr, valAddr string) []byte {
+			func(delAddr, valAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					delAddr,
@@ -682,7 +682,7 @@ func (s *StakingTestSuite) TestDelegatorValidator() {
 			delAddr, err := sdk.AccAddressFromBech32(d[0].DelegatorAddress)
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(delAddr.String(), operatorAddress.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(delAddr.Bytes()), common.Address(operatorAddress.Bytes())), s.signerOne, 10000000)
 
 			if tc.expErr {
 				s.Require().Error(err)

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -1,16 +1,14 @@
 package staking
 
 import (
-	"fmt"
 	"strings"
 
-	precopmiles_common "github.com/0glabs/0g-chain/precompiles/common"
-	"github.com/cosmos/cosmos-sdk/store/types"
+	precompiles_common "github.com/0glabs/0g-chain/precompiles/common"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/evmos/ethermint/x/evm/statedb"
 )
 
 const (
@@ -40,6 +38,7 @@ const (
 )
 
 var _ vm.PrecompiledContract = &StakingPrecompile{}
+var _ precompiles_common.PrecompileCommon = &StakingPrecompile{}
 
 type StakingPrecompile struct {
 	abi           abi.ABI
@@ -67,6 +66,10 @@ func (s *StakingPrecompile) RequiredGas(input []byte) uint64 {
 	return 0
 }
 
+func (s *StakingPrecompile) Abi() *abi.ABI {
+	return &s.abi
+}
+
 func (s *StakingPrecompile) IsTx(method string) bool {
 	switch method {
 	case StakingFunctionCreateValidator,
@@ -81,33 +84,16 @@ func (s *StakingPrecompile) IsTx(method string) bool {
 	}
 }
 
+func (s *StakingPrecompile) KVGasConfig() storetypes.GasConfig {
+	return storetypes.KVGasConfig()
+}
+
 // Run implements vm.PrecompiledContract.
 func (s *StakingPrecompile) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
-	// parse input
-	if len(contract.Input) < 4 {
-		return nil, vm.ErrExecutionReverted
-	}
-	method, err := s.abi.MethodById(contract.Input[:4])
-	if err != nil {
-		return nil, vm.ErrExecutionReverted
-	}
-	args, err := method.Inputs.Unpack(contract.Input[4:])
+	ctx, stateDB, method, initialGas, args, err := precompiles_common.InitializePrecompileCall(s, evm, contract, readonly)
 	if err != nil {
 		return nil, err
 	}
-	// readonly check
-	if readonly && s.IsTx(method.Name) {
-		return nil, fmt.Errorf(precopmiles_common.ErrWriteOnReadOnly)
-	}
-	// get state db and context
-	stateDB, ok := evm.StateDB.(*statedb.StateDB)
-	if !ok {
-		return nil, fmt.Errorf(precopmiles_common.ErrGetStateDB)
-	}
-	ctx := stateDB.GetContext()
-	// reset gas config
-	ctx = ctx.WithKVGasConfig(types.KVGasConfig())
-	initialGas := ctx.GasMeter().GasConsumed()
 
 	var bz []byte
 	switch method.Name {

--- a/precompiles/staking/staking_test.go
+++ b/precompiles/staking/staking_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/evmos/ethermint/x/evm/statedb"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"github.com/stretchr/testify/suite"
 )
@@ -137,7 +138,11 @@ func (suite *StakingTestSuite) runTx(input []byte, signer *testutil.TestSigner, 
 	precompiles := suite.EvmKeeper.GetPrecompiles()
 	evm.WithPrecompiles(precompiles, []common.Address{suite.addr})
 
-	return suite.staking.Run(evm, contract, false)
+	bz, err := suite.staking.Run(evm, contract, false)
+	if err == nil {
+		evm.StateDB.(*statedb.StateDB).Commit()
+	}
+	return bz, err
 }
 
 func TestKeeperSuite(t *testing.T) {

--- a/precompiles/staking/tx.go
+++ b/precompiles/staking/tx.go
@@ -1,10 +1,10 @@
 package staking
 
 import (
-	"fmt"
+	"errors"
 	"math/big"
 
-	precopmiles_common "github.com/0glabs/0g-chain/precompiles/common"
+	precompiles_common "github.com/0glabs/0g-chain/precompiles/common"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -20,13 +20,13 @@ func (s *StakingPrecompile) CreateValidator(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, err := NewMsgCreateValidator(args, evm.Origin, s.stakingKeeper.BondDenom(ctx))
+	msg, err := NewMsgCreateValidator(args, contract.CallerAddress, s.stakingKeeper.BondDenom(ctx))
 	if err != nil {
 		return nil, err
 	}
 	// validation
 	if contract.CallerAddress != evm.Origin {
-		return nil, fmt.Errorf(precopmiles_common.ErrSenderNotOrigin)
+		return nil, errors.New(precompiles_common.ErrSenderNotOrigin)
 	}
 	// execute
 	_, err = stakingkeeper.NewMsgServerImpl(s.stakingKeeper).CreateValidator(ctx, msg)
@@ -45,13 +45,13 @@ func (s *StakingPrecompile) EditValidator(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, err := NewMsgEditValidator(args, evm.Origin)
+	msg, err := NewMsgEditValidator(args, contract.CallerAddress)
 	if err != nil {
 		return nil, err
 	}
 	// validation
 	if contract.CallerAddress != evm.Origin {
-		return nil, fmt.Errorf(precopmiles_common.ErrSenderNotOrigin)
+		return nil, errors.New(precompiles_common.ErrSenderNotOrigin)
 	}
 	// execute
 	_, err = stakingkeeper.NewMsgServerImpl(s.stakingKeeper).EditValidator(ctx, msg)
@@ -70,14 +70,16 @@ func (s *StakingPrecompile) Delegate(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, err := NewMsgDelegate(args, evm.Origin, s.stakingKeeper.BondDenom(ctx))
+	msg, err := NewMsgDelegate(args, contract.CallerAddress, s.stakingKeeper.BondDenom(ctx))
 	if err != nil {
 		return nil, err
 	}
 	// validation
-	if contract.CallerAddress != evm.Origin {
-		return nil, fmt.Errorf(precopmiles_common.ErrSenderNotOrigin)
-	}
+	/*
+		if contract.CallerAddress != evm.Origin {
+			return nil, errors.New(precompiles_common.ErrSenderNotOrigin)
+		}
+	*/
 	// execute
 	_, err = stakingkeeper.NewMsgServerImpl(s.stakingKeeper).Delegate(ctx, msg)
 	if err != nil {
@@ -95,14 +97,16 @@ func (s *StakingPrecompile) BeginRedelegate(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, err := NewMsgBeginRedelegate(args, evm.Origin, s.stakingKeeper.BondDenom(ctx))
+	msg, err := NewMsgBeginRedelegate(args, contract.CallerAddress, s.stakingKeeper.BondDenom(ctx))
 	if err != nil {
 		return nil, err
 	}
 	// validation
-	if contract.CallerAddress != evm.Origin {
-		return nil, fmt.Errorf(precopmiles_common.ErrSenderNotOrigin)
-	}
+	/*
+		if contract.CallerAddress != evm.Origin {
+			return nil, errors.New(precompiles_common.ErrSenderNotOrigin)
+		}
+	*/
 	// execute
 	response, err := stakingkeeper.NewMsgServerImpl(s.stakingKeeper).BeginRedelegate(ctx, msg)
 	if err != nil {
@@ -120,14 +124,16 @@ func (s *StakingPrecompile) Undelegate(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, err := NewMsgUndelegate(args, evm.Origin, s.stakingKeeper.BondDenom(ctx))
+	msg, err := NewMsgUndelegate(args, contract.CallerAddress, s.stakingKeeper.BondDenom(ctx))
 	if err != nil {
 		return nil, err
 	}
 	// validation
-	if contract.CallerAddress != evm.Origin {
-		return nil, fmt.Errorf(precopmiles_common.ErrSenderNotOrigin)
-	}
+	/*
+		if contract.CallerAddress != evm.Origin {
+			return nil, errors.New(precompiles_common.ErrSenderNotOrigin)
+		}
+	*/
 	// execute
 	response, err := stakingkeeper.NewMsgServerImpl(s.stakingKeeper).Undelegate(ctx, msg)
 	if err != nil {
@@ -145,14 +151,16 @@ func (s *StakingPrecompile) CancelUnbondingDelegation(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
-	msg, err := NewMsgCancelUnbondingDelegation(args, evm.Origin, s.stakingKeeper.BondDenom(ctx))
+	msg, err := NewMsgCancelUnbondingDelegation(args, contract.CallerAddress, s.stakingKeeper.BondDenom(ctx))
 	if err != nil {
 		return nil, err
 	}
 	// validation
-	if contract.CallerAddress != evm.Origin {
-		return nil, fmt.Errorf(precopmiles_common.ErrSenderNotOrigin)
-	}
+	/*
+		if contract.CallerAddress != evm.Origin {
+			return nil, errors.New(precompiles_common.ErrSenderNotOrigin)
+		}
+	*/
 	// execute
 	_, err = stakingkeeper.NewMsgServerImpl(s.stakingKeeper).CancelUnbondingDelegation(ctx, msg)
 	if err != nil {

--- a/precompiles/staking/tx_test.go
+++ b/precompiles/staking/tx_test.go
@@ -224,7 +224,7 @@ func (s *StakingTestSuite) TestDelegate() {
 
 	testCases := []struct {
 		name          string
-		malleate      func(valAddr string) []byte
+		malleate      func(valAddr common.Address) []byte
 		gas           uint64
 		callerAddress *common.Address
 		postCheck     func(valAddr sdk.ValAddress)
@@ -233,7 +233,7 @@ func (s *StakingTestSuite) TestDelegate() {
 	}{
 		{
 			"success",
-			func(valAddr string) []byte {
+			func(valAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					valAddr,
@@ -265,7 +265,7 @@ func (s *StakingTestSuite) TestDelegate() {
 			operatorAddress, err := s.firstBondedValidator()
 			s.Require().NoError(err)
 
-			bz, err := s.runTx(tc.malleate(operatorAddress.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(common.Address(operatorAddress)), s.signerOne, 10000000)
 
 			if tc.expError {
 				s.Require().ErrorContains(err, tc.errContains)
@@ -283,7 +283,7 @@ func (s *StakingTestSuite) TestBeginRedelegate() {
 
 	testCases := []struct {
 		name          string
-		malleate      func(srcAddr, dstAddr string) []byte
+		malleate      func(srcAddr, dstAddr common.Address) []byte
 		gas           uint64
 		callerAddress *common.Address
 		postCheck     func(data []byte, srcAddr, dstAddr sdk.ValAddress)
@@ -292,7 +292,7 @@ func (s *StakingTestSuite) TestBeginRedelegate() {
 	}{
 		{
 			"success",
-			func(srcAddr, dstAddr string) []byte {
+			func(srcAddr, dstAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					srcAddr,
@@ -337,7 +337,7 @@ func (s *StakingTestSuite) TestBeginRedelegate() {
 
 			s.setupValidator(s.signerOne)
 
-			bz, err := s.runTx(tc.malleate(s.signerOne.ValAddr.String(), operatorAddress.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(s.signerOne.Addr, common.Address(operatorAddress.Bytes())), s.signerOne, 10000000)
 
 			if tc.expError {
 				s.Require().ErrorContains(err, tc.errContains)
@@ -355,7 +355,7 @@ func (s *StakingTestSuite) TestUndelegate() {
 
 	testCases := []struct {
 		name          string
-		malleate      func(valAddr string) []byte
+		malleate      func(valAddr common.Address) []byte
 		gas           uint64
 		callerAddress *common.Address
 		postCheck     func(data []byte, valAddr sdk.ValAddress)
@@ -364,7 +364,7 @@ func (s *StakingTestSuite) TestUndelegate() {
 	}{
 		{
 			"success",
-			func(valAddr string) []byte {
+			func(valAddr common.Address) []byte {
 				input, err := s.abi.Pack(
 					method,
 					valAddr,
@@ -405,7 +405,7 @@ func (s *StakingTestSuite) TestUndelegate() {
 
 			s.setupValidator(s.signerOne)
 
-			bz, err := s.runTx(tc.malleate(s.signerOne.ValAddr.String()), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(s.signerOne.Addr), s.signerOne, 10000000)
 
 			if tc.expError {
 				s.Require().ErrorContains(err, tc.errContains)
@@ -423,7 +423,7 @@ func (s *StakingTestSuite) TestCancelUnbondingDelegation() {
 
 	testCases := []struct {
 		name          string
-		malleate      func(valAddr string, height *big.Int) []byte
+		malleate      func(valAddr common.Address, height *big.Int) []byte
 		gas           uint64
 		callerAddress *common.Address
 		postCheck     func(valAddr sdk.ValAddress)
@@ -432,7 +432,7 @@ func (s *StakingTestSuite) TestCancelUnbondingDelegation() {
 	}{
 		{
 			"success",
-			func(valAddr string, height *big.Int) []byte {
+			func(valAddr common.Address, height *big.Int) []byte {
 				input, err := s.abi.Pack(
 					method,
 					valAddr,
@@ -471,7 +471,7 @@ func (s *StakingTestSuite) TestCancelUnbondingDelegation() {
 			u, _ := s.stakingKeeper.GetUnbondingDelegation(s.Ctx, s.signerOne.AccAddr, s.signerOne.ValAddr)
 			height := u.Entries[0].CreationHeight
 
-			bz, err := s.runTx(tc.malleate(s.signerOne.ValAddr.String(), big.NewInt(height)), s.signerOne, 10000000)
+			bz, err := s.runTx(tc.malleate(s.signerOne.Addr, big.NewInt(height)), s.signerOne, 10000000)
 
 			if tc.expError {
 				s.Require().ErrorContains(err, tc.errContains)

--- a/precompiles/staking/types.go
+++ b/precompiles/staking/types.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 
 	"cosmossdk.io/math"
-	precopmiles_common "github.com/0glabs/0g-chain/precompiles/common"
+	precompiles_common "github.com/0glabs/0g-chain/precompiles/common"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -29,9 +29,9 @@ type CommissionRates = struct {
 }
 
 type Delegation = struct {
-	DelegatorAddress string   `json:"delegatorAddress"`
-	ValidatorAddress string   `json:"validatorAddress"`
-	Shares           *big.Int `json:"shares"`
+	DelegatorAddress common.Address `json:"delegatorAddress"`
+	ValidatorAddress common.Address `json:"validatorAddress"`
+	Shares           *big.Int       `json:"shares"`
 }
 
 type DelegationResponse = struct {
@@ -75,9 +75,9 @@ type Params = struct {
 }
 
 type Redelegation = struct {
-	DelegatorAddress    string              `json:"delegatorAddress"`
-	ValidatorSrcAddress string              `json:"validatorSrcAddress"`
-	ValidatorDstAddress string              `json:"validatorDstAddress"`
+	DelegatorAddress    common.Address      `json:"delegatorAddress"`
+	ValidatorSrcAddress common.Address      `json:"validatorSrcAddress"`
+	ValidatorDstAddress common.Address      `json:"validatorDstAddress"`
 	Entries             []RedelegationEntry `json:"entries"`
 }
 
@@ -101,8 +101,8 @@ type RedelegationResponse = struct {
 }
 
 type UnbondingDelegation = struct {
-	DelegatorAddress string                     `json:"delegatorAddress"`
-	ValidatorAddress string                     `json:"validatorAddress"`
+	DelegatorAddress common.Address             `json:"delegatorAddress"`
+	ValidatorAddress common.Address             `json:"validatorAddress"`
 	Entries          []UnbondingDelegationEntry `json:"entries"`
 }
 
@@ -116,29 +116,28 @@ type UnbondingDelegationEntry = struct {
 }
 
 type Validator = struct {
-	OperatorAddress         string      `json:"operatorAddress"`
-	ConsensusPubkey         string      `json:"consensusPubkey"`
-	Jailed                  bool        `json:"jailed"`
-	Status                  uint8       `json:"status"`
-	Tokens                  *big.Int    `json:"tokens"`
-	DelegatorShares         *big.Int    `json:"delegatorShares"`
-	Description             Description `json:"description"`
-	UnbondingHeight         int64       `json:"unbondingHeight"`
-	UnbondingTime           int64       `json:"unbondingTime"`
-	Commission              Commission  `json:"commission"`
-	MinSelfDelegation       *big.Int    `json:"minSelfDelegation"`
-	UnbondingOnHoldRefCount int64       `json:"unbondingOnHoldRefCount"`
-	UnbondingIds            []uint64    `json:"unbondingIds"`
+	OperatorAddress         common.Address `json:"operatorAddress"`
+	ConsensusPubkey         string         `json:"consensusPubkey"`
+	Jailed                  bool           `json:"jailed"`
+	Status                  uint8          `json:"status"`
+	Tokens                  *big.Int       `json:"tokens"`
+	DelegatorShares         *big.Int       `json:"delegatorShares"`
+	Description             Description    `json:"description"`
+	UnbondingHeight         int64          `json:"unbondingHeight"`
+	UnbondingTime           int64          `json:"unbondingTime"`
+	Commission              Commission     `json:"commission"`
+	MinSelfDelegation       *big.Int       `json:"minSelfDelegation"`
+	UnbondingOnHoldRefCount int64          `json:"unbondingOnHoldRefCount"`
+	UnbondingIds            []uint64       `json:"unbondingIds"`
 }
 
-func convertValidator(v stakingtypes.Validator) Validator {
+func convertValidator(v stakingtypes.Validator) (Validator, error) {
 	validator := Validator{}
 	operatorAddress, err := sdk.ValAddressFromBech32(v.OperatorAddress)
 	if err != nil {
-		validator.OperatorAddress = v.OperatorAddress
-	} else {
-		validator.OperatorAddress = common.BytesToAddress(operatorAddress.Bytes()).String()
+		return validator, err
 	}
+	validator.OperatorAddress = common.BytesToAddress(operatorAddress.Bytes())
 
 	ed25519pk, ok := v.ConsensusPubkey.GetCachedValue().(cryptotypes.PubKey)
 	if !ok {
@@ -167,7 +166,7 @@ func convertValidator(v stakingtypes.Validator) Validator {
 	validator.MinSelfDelegation = v.MinSelfDelegation.BigInt()
 	validator.UnbondingOnHoldRefCount = v.UnbondingOnHoldRefCount
 	validator.UnbondingIds = v.UnbondingIds
-	return validator
+	return validator, nil
 }
 
 func convertQueryPageRequest(pagination PageRequest) *query.PageRequest {
@@ -205,9 +204,9 @@ func convertStakingDescription(description Description) stakingtypes.Description
 
 func convertStakingCommissionRates(commission CommissionRates) stakingtypes.CommissionRates {
 	return stakingtypes.CommissionRates{
-		Rate:          precopmiles_common.BigIntToLegacyDec(commission.Rate),
-		MaxRate:       precopmiles_common.BigIntToLegacyDec(commission.MaxRate),
-		MaxChangeRate: precopmiles_common.BigIntToLegacyDec(commission.MaxChangeRate),
+		Rate:          precompiles_common.BigIntToLegacyDec(commission.Rate),
+		MaxRate:       precompiles_common.BigIntToLegacyDec(commission.MaxRate),
+		MaxChangeRate: precompiles_common.BigIntToLegacyDec(commission.MaxChangeRate),
 	}
 }
 
@@ -219,19 +218,31 @@ func convertCommissionRates(commission stakingtypes.CommissionRates) CommissionR
 	}
 }
 
-func convertDelegation(delegation stakingtypes.Delegation) Delegation {
-	return Delegation{
-		DelegatorAddress: delegation.DelegatorAddress,
-		ValidatorAddress: delegation.ValidatorAddress,
-		Shares:           delegation.Shares.BigInt(),
+func convertDelegation(delegation stakingtypes.Delegation) (Delegation, error) {
+	delegatorAddress, err := sdk.AccAddressFromBech32(delegation.DelegatorAddress)
+	if err != nil {
+		return Delegation{}, err
 	}
+	validatorAddress, err := sdk.ValAddressFromBech32(delegation.ValidatorAddress)
+	if err != nil {
+		return Delegation{}, err
+	}
+	return Delegation{
+		DelegatorAddress: common.BytesToAddress(delegatorAddress.Bytes()),
+		ValidatorAddress: common.BytesToAddress(validatorAddress.Bytes()),
+		Shares:           delegation.Shares.BigInt(),
+	}, nil
 }
 
-func convertDelegationResponse(response stakingtypes.DelegationResponse) DelegationResponse {
-	return DelegationResponse{
-		Delegation: convertDelegation(response.Delegation),
-		Balance:    response.Balance.Amount.BigInt(),
+func convertDelegationResponse(response stakingtypes.DelegationResponse) (DelegationResponse, error) {
+	delegation, err := convertDelegation(response.Delegation)
+	if err != nil {
+		return DelegationResponse{}, err
 	}
+	return DelegationResponse{
+		Delegation: delegation,
+		Balance:    response.Balance.Amount.BigInt(),
+	}, nil
 }
 
 func convertUnbondingDelegationEntry(entry stakingtypes.UnbondingDelegationEntry) UnbondingDelegationEntry {
@@ -245,16 +256,24 @@ func convertUnbondingDelegationEntry(entry stakingtypes.UnbondingDelegationEntry
 	}
 }
 
-func convertUnbondingDelegation(response stakingtypes.UnbondingDelegation) UnbondingDelegation {
+func convertUnbondingDelegation(response stakingtypes.UnbondingDelegation) (UnbondingDelegation, error) {
 	entries := make([]UnbondingDelegationEntry, len(response.Entries))
 	for i, v := range response.Entries {
 		entries[i] = convertUnbondingDelegationEntry(v)
 	}
-	return UnbondingDelegation{
-		DelegatorAddress: response.DelegatorAddress,
-		ValidatorAddress: response.ValidatorAddress,
-		Entries:          entries,
+	delegatorAddress, err := sdk.AccAddressFromBech32(response.DelegatorAddress)
+	if err != nil {
+		return UnbondingDelegation{}, err
 	}
+	validatorAddress, err := sdk.ValAddressFromBech32(response.ValidatorAddress)
+	if err != nil {
+		return UnbondingDelegation{}, err
+	}
+	return UnbondingDelegation{
+		DelegatorAddress: common.BytesToAddress(delegatorAddress.Bytes()),
+		ValidatorAddress: common.BytesToAddress(validatorAddress.Bytes()),
+		Entries:          entries,
+	}, nil
 }
 
 func convertRedelegationEntry(entry stakingtypes.RedelegationEntry) RedelegationEntry {
@@ -268,17 +287,29 @@ func convertRedelegationEntry(entry stakingtypes.RedelegationEntry) Redelegation
 	}
 }
 
-func convertRedelegation(redelegation stakingtypes.Redelegation) Redelegation {
+func convertRedelegation(redelegation stakingtypes.Redelegation) (Redelegation, error) {
 	entries := make([]RedelegationEntry, len(redelegation.Entries))
 	for i, v := range redelegation.Entries {
 		entries[i] = convertRedelegationEntry(v)
 	}
-	return Redelegation{
-		DelegatorAddress:    redelegation.DelegatorAddress,
-		ValidatorSrcAddress: redelegation.ValidatorSrcAddress,
-		ValidatorDstAddress: redelegation.ValidatorDstAddress,
-		Entries:             entries,
+	delegatorAddress, err := sdk.AccAddressFromBech32(redelegation.DelegatorAddress)
+	if err != nil {
+		return Redelegation{}, err
 	}
+	validatorSrcAddress, err := sdk.ValAddressFromBech32(redelegation.ValidatorSrcAddress)
+	if err != nil {
+		return Redelegation{}, err
+	}
+	validatorDstAddress, err := sdk.ValAddressFromBech32(redelegation.ValidatorDstAddress)
+	if err != nil {
+		return Redelegation{}, err
+	}
+	return Redelegation{
+		DelegatorAddress:    common.BytesToAddress(delegatorAddress.Bytes()),
+		ValidatorSrcAddress: common.BytesToAddress(validatorSrcAddress.Bytes()),
+		ValidatorDstAddress: common.BytesToAddress(validatorDstAddress.Bytes()),
+		Entries:             entries,
+	}, nil
 }
 
 func convertRedelegationEntryResponse(response stakingtypes.RedelegationEntryResponse) RedelegationEntryResponse {
@@ -288,15 +319,19 @@ func convertRedelegationEntryResponse(response stakingtypes.RedelegationEntryRes
 	}
 }
 
-func convertRedelegationResponse(response stakingtypes.RedelegationResponse) RedelegationResponse {
+func convertRedelegationResponse(response stakingtypes.RedelegationResponse) (RedelegationResponse, error) {
 	entries := make([]RedelegationEntryResponse, len(response.Entries))
 	for i, v := range response.Entries {
 		entries[i] = convertRedelegationEntryResponse(v)
 	}
-	return RedelegationResponse{
-		Redelegation: convertRedelegation(response.Redelegation),
-		Entries:      entries,
+	redelegation, err := convertRedelegation(response.Redelegation)
+	if err != nil {
+		return RedelegationResponse{}, nil
 	}
+	return RedelegationResponse{
+		Redelegation: redelegation,
+		Entries:      entries,
+	}, nil
 }
 
 func convertParams(params stakingtypes.Params) Params {
@@ -312,7 +347,7 @@ func convertParams(params stakingtypes.Params) Params {
 
 func NewMsgCreateValidator(args []interface{}, sender common.Address, denom string) (*stakingtypes.MsgCreateValidator, error) {
 	if len(args) != 5 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 5, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 5, len(args))
 	}
 	description := args[0].(Description)
 	commission := args[1].(CommissionRates)
@@ -349,14 +384,14 @@ func NewMsgCreateValidator(args []interface{}, sender common.Address, denom stri
 
 func NewMsgEditValidator(args []interface{}, sender common.Address) (*stakingtypes.MsgEditValidator, error) {
 	if len(args) != 3 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 3, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 3, len(args))
 	}
 	description := args[0].(Description)
 
 	commissionRateNullable := args[1].(NullableUint)
 	var commissionRate *sdk.Dec
 	if !commissionRateNullable.IsNull {
-		value := precopmiles_common.BigIntToLegacyDec(commissionRateNullable.Value)
+		value := precompiles_common.BigIntToLegacyDec(commissionRateNullable.Value)
 		commissionRate = &value
 	}
 
@@ -378,14 +413,14 @@ func NewMsgEditValidator(args []interface{}, sender common.Address) (*stakingtyp
 
 func NewMsgDelegate(args []interface{}, sender common.Address, denom string) (*stakingtypes.MsgDelegate, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	validatorAddress := args[0].(string)
+	validatorAddress := args[0].(common.Address)
 	amount := args[1].(*big.Int)
 
 	msg := &stakingtypes.MsgDelegate{
 		DelegatorAddress: sdk.AccAddress(sender.Bytes()).String(),
-		ValidatorAddress: validatorAddress,
+		ValidatorAddress: sdk.ValAddress(validatorAddress.Bytes()).String(),
 		Amount:           sdk.Coin{Denom: denom, Amount: math.NewIntFromBigInt(amount)},
 	}
 	return msg, msg.ValidateBasic()
@@ -393,16 +428,16 @@ func NewMsgDelegate(args []interface{}, sender common.Address, denom string) (*s
 
 func NewMsgBeginRedelegate(args []interface{}, sender common.Address, denom string) (*stakingtypes.MsgBeginRedelegate, error) {
 	if len(args) != 3 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 3, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 3, len(args))
 	}
-	validatorSrcAddress := args[0].(string)
-	validatorDstAddress := args[1].(string)
+	validatorSrcAddress := args[0].(common.Address)
+	validatorDstAddress := args[1].(common.Address)
 	amount := args[2].(*big.Int)
 
 	msg := &stakingtypes.MsgBeginRedelegate{
 		DelegatorAddress:    sdk.AccAddress(sender.Bytes()).String(),
-		ValidatorSrcAddress: validatorSrcAddress,
-		ValidatorDstAddress: validatorDstAddress,
+		ValidatorSrcAddress: sdk.ValAddress(validatorSrcAddress.Bytes()).String(),
+		ValidatorDstAddress: sdk.ValAddress(validatorDstAddress.Bytes()).String(),
 		Amount:              sdk.Coin{Denom: denom, Amount: math.NewIntFromBigInt(amount)},
 	}
 	return msg, msg.ValidateBasic()
@@ -410,14 +445,14 @@ func NewMsgBeginRedelegate(args []interface{}, sender common.Address, denom stri
 
 func NewMsgUndelegate(args []interface{}, sender common.Address, denom string) (*stakingtypes.MsgUndelegate, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	validatorAddress := args[0].(string)
+	validatorAddress := args[0].(common.Address)
 	amount := args[1].(*big.Int)
 
 	msg := &stakingtypes.MsgUndelegate{
 		DelegatorAddress: sdk.AccAddress(sender.Bytes()).String(),
-		ValidatorAddress: validatorAddress,
+		ValidatorAddress: sdk.ValAddress(validatorAddress.Bytes()).String(),
 		Amount:           sdk.Coin{Denom: denom, Amount: math.NewIntFromBigInt(amount)},
 	}
 	return msg, msg.ValidateBasic()
@@ -425,15 +460,15 @@ func NewMsgUndelegate(args []interface{}, sender common.Address, denom string) (
 
 func NewMsgCancelUnbondingDelegation(args []interface{}, sender common.Address, denom string) (*stakingtypes.MsgCancelUnbondingDelegation, error) {
 	if len(args) != 3 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 3, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 3, len(args))
 	}
-	validatorAddress := args[0].(string)
+	validatorAddress := args[0].(common.Address)
 	amount := args[1].(*big.Int)
 	creationHeight := args[2].(*big.Int)
 
 	msg := &stakingtypes.MsgCancelUnbondingDelegation{
 		DelegatorAddress: sdk.AccAddress(sender.Bytes()).String(),
-		ValidatorAddress: validatorAddress,
+		ValidatorAddress: sdk.ValAddress(validatorAddress.Bytes()).String(),
 		Amount:           sdk.Coin{Denom: denom, Amount: math.NewIntFromBigInt(amount)},
 		CreationHeight:   creationHeight.Int64(),
 	}
@@ -442,7 +477,7 @@ func NewMsgCancelUnbondingDelegation(args []interface{}, sender common.Address, 
 
 func NewQueryValidatorsRequest(args []interface{}) (*stakingtypes.QueryValidatorsRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
 	status := args[0].(string)
 	pagination := args[1].(PageRequest)
@@ -455,139 +490,139 @@ func NewQueryValidatorsRequest(args []interface{}) (*stakingtypes.QueryValidator
 
 func NewQueryValidatorRequest(args []interface{}) (*stakingtypes.QueryValidatorRequest, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 1, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 1, len(args))
 	}
-	validatorAddress := args[0].(string)
+	validatorAddress := args[0].(common.Address)
 
 	return &stakingtypes.QueryValidatorRequest{
-		ValidatorAddr: validatorAddress,
+		ValidatorAddr: sdk.ValAddress(validatorAddress.Bytes()).String(),
 	}, nil
 }
 
 func NewQueryValidatorDelegationsRequest(args []interface{}) (*stakingtypes.QueryValidatorDelegationsRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	validatorAddr := args[0].(string)
+	validatorAddr := args[0].(common.Address)
 	pagination := args[1].(PageRequest)
 
 	return &stakingtypes.QueryValidatorDelegationsRequest{
-		ValidatorAddr: validatorAddr,
+		ValidatorAddr: sdk.ValAddress(validatorAddr.Bytes()).String(),
 		Pagination:    convertQueryPageRequest(pagination),
 	}, nil
 }
 
 func NewQueryValidatorUnbondingDelegationsRequest(args []interface{}) (*stakingtypes.QueryValidatorUnbondingDelegationsRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	validatorAddr := args[0].(string)
+	validatorAddr := args[0].(common.Address)
 	pagination := args[1].(PageRequest)
 
 	return &stakingtypes.QueryValidatorUnbondingDelegationsRequest{
-		ValidatorAddr: validatorAddr,
+		ValidatorAddr: sdk.ValAddress(validatorAddr.Bytes()).String(),
 		Pagination:    convertQueryPageRequest(pagination),
 	}, nil
 }
 
 func NewQueryDelegationRequest(args []interface{}) (*stakingtypes.QueryDelegationRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	delegatorAddr := args[0].(string)
-	validatorAddr := args[1].(string)
+	delegatorAddr := args[0].(common.Address)
+	validatorAddr := args[1].(common.Address)
 
 	return &stakingtypes.QueryDelegationRequest{
-		DelegatorAddr: delegatorAddr,
-		ValidatorAddr: validatorAddr,
+		DelegatorAddr: sdk.AccAddress(delegatorAddr.Bytes()).String(),
+		ValidatorAddr: sdk.ValAddress(validatorAddr.Bytes()).String(),
 	}, nil
 }
 
 func NewQueryUnbondingDelegationRequest(args []interface{}) (*stakingtypes.QueryUnbondingDelegationRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	delegatorAddr := args[0].(string)
-	validatorAddr := args[1].(string)
+	delegatorAddr := args[0].(common.Address)
+	validatorAddr := args[1].(common.Address)
 
 	return &stakingtypes.QueryUnbondingDelegationRequest{
-		DelegatorAddr: delegatorAddr,
-		ValidatorAddr: validatorAddr,
+		DelegatorAddr: sdk.AccAddress(delegatorAddr.Bytes()).String(),
+		ValidatorAddr: sdk.ValAddress(validatorAddr.Bytes()).String(),
 	}, nil
 }
 
 func NewQueryDelegatorDelegationsRequest(args []interface{}) (*stakingtypes.QueryDelegatorDelegationsRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	delegatorAddr := args[0].(string)
+	delegatorAddr := args[0].(common.Address)
 	pagination := args[1].(PageRequest)
 
 	return &stakingtypes.QueryDelegatorDelegationsRequest{
-		DelegatorAddr: delegatorAddr,
+		DelegatorAddr: sdk.AccAddress(delegatorAddr.Bytes()).String(),
 		Pagination:    convertQueryPageRequest(pagination),
 	}, nil
 }
 
 func NewQueryDelegatorUnbondingDelegationsRequest(args []interface{}) (*stakingtypes.QueryDelegatorUnbondingDelegationsRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	delegatorAddr := args[0].(string)
+	delegatorAddr := args[0].(common.Address)
 	pagination := args[1].(PageRequest)
 
 	return &stakingtypes.QueryDelegatorUnbondingDelegationsRequest{
-		DelegatorAddr: delegatorAddr,
+		DelegatorAddr: sdk.AccAddress(delegatorAddr.Bytes()).String(),
 		Pagination:    convertQueryPageRequest(pagination),
 	}, nil
 }
 
 func NewQueryRedelegationsRequest(args []interface{}) (*stakingtypes.QueryRedelegationsRequest, error) {
 	if len(args) != 4 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 4, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 4, len(args))
 	}
-	delegatorAddress := args[0].(string)
-	validatorSrcAddress := args[1].(string)
-	validatorDstAddress := args[2].(string)
+	delegatorAddress := args[0].(common.Address)
+	validatorSrcAddress := args[1].(common.Address)
+	validatorDstAddress := args[2].(common.Address)
 	pagination := args[3].(PageRequest)
 
 	return &stakingtypes.QueryRedelegationsRequest{
-		DelegatorAddr:    delegatorAddress,
-		SrcValidatorAddr: validatorSrcAddress,
-		DstValidatorAddr: validatorDstAddress,
+		DelegatorAddr:    sdk.AccAddress(delegatorAddress.Bytes()).String(),
+		SrcValidatorAddr: sdk.ValAddress(validatorSrcAddress.Bytes()).String(),
+		DstValidatorAddr: sdk.ValAddress(validatorDstAddress.Bytes()).String(),
 		Pagination:       convertQueryPageRequest(pagination),
 	}, nil
 }
 
 func NewQueryDelegatorValidatorsRequest(args []interface{}) (*stakingtypes.QueryDelegatorValidatorsRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	delegatorAddr := args[0].(string)
+	delegatorAddr := args[0].(common.Address)
 	pagination := args[1].(PageRequest)
 
 	return &stakingtypes.QueryDelegatorValidatorsRequest{
-		DelegatorAddr: delegatorAddr,
+		DelegatorAddr: sdk.AccAddress(delegatorAddr.Bytes()).String(),
 		Pagination:    convertQueryPageRequest(pagination),
 	}, nil
 }
 
 func NewQueryDelegatorValidatorRequest(args []interface{}) (*stakingtypes.QueryDelegatorValidatorRequest, error) {
 	if len(args) != 2 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 2, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 2, len(args))
 	}
-	delegatorAddr := args[0].(string)
-	validatorAddr := args[1].(string)
+	delegatorAddr := args[0].(common.Address)
+	validatorAddr := args[1].(common.Address)
 
 	return &stakingtypes.QueryDelegatorValidatorRequest{
-		DelegatorAddr: delegatorAddr,
-		ValidatorAddr: validatorAddr,
+		DelegatorAddr: sdk.AccAddress(delegatorAddr.Bytes()).String(),
+		ValidatorAddr: sdk.ValAddress(validatorAddr.Bytes()).String(),
 	}, nil
 }
 
 func NewQueryPoolRequest(args []interface{}) (*stakingtypes.QueryPoolRequest, error) {
 	if len(args) != 0 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 0, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 0, len(args))
 	}
 
 	return &stakingtypes.QueryPoolRequest{}, nil
@@ -595,7 +630,7 @@ func NewQueryPoolRequest(args []interface{}) (*stakingtypes.QueryPoolRequest, er
 
 func NewQueryParamsRequest(args []interface{}) (*stakingtypes.QueryParamsRequest, error) {
 	if len(args) != 0 {
-		return nil, fmt.Errorf(precopmiles_common.ErrInvalidNumberOfArgs, 0, len(args))
+		return nil, fmt.Errorf(precompiles_common.ErrInvalidNumberOfArgs, 0, len(args))
 	}
 
 	return &stakingtypes.QueryParamsRequest{}, nil


### PR DESCRIPTION
- Add initialization before each precompile calls to make snapshot of current StatDB and do basic validations;
- Refactored staking module to make its arguments readable to EVM contracts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-chain/94)
<!-- Reviewable:end -->
